### PR TITLE
Add index store output to objc_library

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -1297,7 +1297,8 @@ public final class CcCompilationHelper {
               && CppFileTypes.LTO_SOURCE.matches(sourceArtifact.getFilename());
 
       boolean indexWhileBuilding =
-              featureConfiguration.isEnabled(CppRuleClasses.INDEX_WHILE_BUILDING);
+          cppConfiguration.indexWhileBuilding()
+              && featureConfiguration.isEnabled(CppRuleClasses.INDEX_WHILE_BUILDING);
 
       String outputName = outputNameMap.get(sourceArtifact);
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -1395,6 +1395,7 @@ public final class CcCompilationHelper {
             /* isUsingFission= */ false,
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
+            null,
             /* additionalBuildVariables= */ ImmutableMap.of()));
     semantics.finalizeCompileActionBuilder(configuration, featureConfiguration, builder);
     // Make sure this builder doesn't reference ruleContext outside of analysis phase.
@@ -1464,6 +1465,7 @@ public final class CcCompilationHelper {
       boolean isUsingFission,
       Artifact dwoFile,
       Artifact ltoIndexingFile,
+      Artifact indexStorePath,
       ImmutableMap<String, String> additionalBuildVariables) {
     Artifact sourceFile = builder.getSourceFile();
     String dotdFileExecPath = null;
@@ -1541,6 +1543,7 @@ public final class CcCompilationHelper {
         toPathString(builder.getOutputFile()),
         toPathString(gcnoFile),
         toPathString(dwoFile),
+        toPathString(indexStorePath),
         isUsingFission,
         toPathString(ltoIndexingFile),
         getCopts(builder.getSourceFile(), sourceLabel),
@@ -1630,6 +1633,7 @@ public final class CcCompilationHelper {
             generateDwo,
             dwoFile,
             /* ltoIndexingFile= */ null,
+            null,
             /* additionalBuildVariables= */ ImmutableMap.of()));
 
     builder.setGcnoFile(gcnoFile);
@@ -1684,6 +1688,7 @@ public final class CcCompilationHelper {
             /* isUsingFission= */ false,
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
+            null,
             /* additionalBuildVariables= */ ImmutableMap.of()));
     semantics.finalizeCompileActionBuilder(configuration, featureConfiguration, builder);
     CppCompileAction compileAction = builder.buildOrThrowRuleError(ruleErrorConsumer);
@@ -1767,6 +1772,11 @@ public final class CcCompilationHelper {
         Artifact ltoIndexingFile =
             bitcodeOutput ? getLtoIndexingFile(picBuilder.getOutputFile()) : null;
 
+        // TODO: guard this with a feature
+        Artifact indexStore = actionConstructionContext.getTreeArtifact(
+                picBuilder.getOutputFile().getRootRelativePath().replaceName(outputName + ".indexstore"),
+                actionConstructionContext.getBinOrGenfilesDirectory());
+
         picBuilder.setVariables(
             setupCompileBuildVariables(
                 picBuilder,
@@ -1778,6 +1788,7 @@ public final class CcCompilationHelper {
                 generateDwo,
                 dwoFile,
                 ltoIndexingFile,
+                indexStore,
                 /* additionalBuildVariables= */ ImmutableMap.of()));
 
         result.addTemps(
@@ -1842,6 +1853,11 @@ public final class CcCompilationHelper {
         Artifact ltoIndexingFile =
             bitcodeOutput ? getLtoIndexingFile(builder.getOutputFile()) : null;
 
+        // TODO: guard this with a feature
+        Artifact indexStore = actionConstructionContext.getTreeArtifact(
+                noPicOutputFile.getRootRelativePath().replaceName(outputName + ".indexstore"),
+                actionConstructionContext.getBinOrGenfilesDirectory());
+
         builder.setVariables(
             setupCompileBuildVariables(
                 builder,
@@ -1853,6 +1869,7 @@ public final class CcCompilationHelper {
                 generateDwo,
                 noPicDwoFile,
                 ltoIndexingFile,
+                indexStore,
                 /* additionalBuildVariables= */ ImmutableMap.of()));
 
         result.addTemps(
@@ -1868,6 +1885,7 @@ public final class CcCompilationHelper {
         builder.setGcnoFile(gcnoFile);
         builder.setDwoFile(noPicDwoFile);
         builder.setLtoIndexingFile(ltoIndexingFile);
+        builder.setIndexStore(indexStore);
 
         semantics.finalizeCompileActionBuilder(configuration, featureConfiguration, builder);
         CppCompileAction compileAction = builder.buildOrThrowRuleError(ruleErrorConsumer);
@@ -1966,6 +1984,7 @@ public final class CcCompilationHelper {
             /* isUsingFission= */ false,
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
+            null,
             /* additionalBuildVariables= */ ImmutableMap.of()));
     semantics.finalizeCompileActionBuilder(configuration, featureConfiguration, builder);
     CppCompileAction action = builder.buildOrThrowRuleError(ruleErrorConsumer);
@@ -2082,6 +2101,7 @@ public final class CcCompilationHelper {
             /* isUsingFission= */ false,
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
+            null,
             ImmutableMap.of(
                 CompileBuildVariables.OUTPUT_PREPROCESS_FILE.getVariableName(),
                 dBuilder.getRealOutputFilePath().getSafePathString())));
@@ -2108,6 +2128,7 @@ public final class CcCompilationHelper {
             /* isUsingFission= */ false,
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
+            null,
             ImmutableMap.of(
                 CompileBuildVariables.OUTPUT_ASSEMBLY_FILE.getVariableName(),
                 sdBuilder.getRealOutputFilePath().getSafePathString())));

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -1399,7 +1399,7 @@ public final class CcCompilationHelper {
             /* isUsingFission= */ false,
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
-            null,
+            /* indexStorePath= */ null,
             /* additionalBuildVariables= */ ImmutableMap.of()));
     semantics.finalizeCompileActionBuilder(configuration, featureConfiguration, builder);
     // Make sure this builder doesn't reference ruleContext outside of analysis phase.
@@ -1637,7 +1637,7 @@ public final class CcCompilationHelper {
             generateDwo,
             dwoFile,
             /* ltoIndexingFile= */ null,
-            null,
+            /* indexStorePath= */null,
             /* additionalBuildVariables= */ ImmutableMap.of()));
 
     builder.setGcnoFile(gcnoFile);
@@ -1692,7 +1692,7 @@ public final class CcCompilationHelper {
             /* isUsingFission= */ false,
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
-            null,
+            /* indexStorePath= */null,
             /* additionalBuildVariables= */ ImmutableMap.of()));
     semantics.finalizeCompileActionBuilder(configuration, featureConfiguration, builder);
     CppCompileAction compileAction = builder.buildOrThrowRuleError(ruleErrorConsumer);
@@ -1983,7 +1983,7 @@ public final class CcCompilationHelper {
             /* isUsingFission= */ false,
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
-            null,
+            /* indexStorePath= */null,
             /* additionalBuildVariables= */ ImmutableMap.of()));
     semantics.finalizeCompileActionBuilder(configuration, featureConfiguration, builder);
     CppCompileAction action = builder.buildOrThrowRuleError(ruleErrorConsumer);
@@ -2107,7 +2107,7 @@ public final class CcCompilationHelper {
             /* isUsingFission= */ false,
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
-            null,
+            /* indexStorePath= */null,
             ImmutableMap.of(
                 CompileBuildVariables.OUTPUT_PREPROCESS_FILE.getVariableName(),
                 dBuilder.getRealOutputFilePath().getSafePathString())));
@@ -2134,7 +2134,7 @@ public final class CcCompilationHelper {
             /* isUsingFission= */ false,
             /* dwoFile= */ null,
             /* ltoIndexingFile= */ null,
-            null,
+            /* indexStorePath= */null,
             ImmutableMap.of(
                 CompileBuildVariables.OUTPUT_ASSEMBLY_FILE.getVariableName(),
                 sdBuilder.getRealOutputFilePath().getSafePathString())));

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -232,7 +232,7 @@ public abstract class CcModule
         convertFromNoneable(sourceFile, /* defaultValue= */ null),
         convertFromNoneable(outputFile, /* defaultValue= */ null),
         /* gcnoFile= */ null,
-        null,
+        /* indexStorePath= */ null,
         /* isUsingFission= */ false,
         /* dwoFile= */ null,
         /* ltoIndexingFile= */ null,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -232,6 +232,7 @@ public abstract class CcModule
         convertFromNoneable(sourceFile, /* defaultValue= */ null),
         convertFromNoneable(outputFile, /* defaultValue= */ null),
         /* gcnoFile= */ null,
+        null,
         /* isUsingFission= */ false,
         /* dwoFile= */ null,
         /* ltoIndexingFile= */ null,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariables.java
@@ -102,7 +102,9 @@ public enum CompileBuildVariables {
   /** Path to the cache prefetch profile artifact */
   FDO_PREFETCH_HINTS_PATH("fdo_prefetch_hints_path"),
   /** Variable for includes that compiler needs to include into sources. */
-  INCLUDES("includes");
+  INCLUDES("includes"),
+  INDEX_STORE_PATH("index_store_path");
+
 
   private final String variableName;
 
@@ -119,6 +121,7 @@ public enum CompileBuildVariables {
       String sourceFile,
       String outputFile,
       String gcnoFile,
+      String indexStorePath,
       boolean isUsingFission,
       String dwoFile,
       String ltoIndexingFile,
@@ -150,6 +153,7 @@ public enum CompileBuildVariables {
           sourceFile,
           outputFile,
           gcnoFile,
+          indexStorePath,
           isUsingFission,
           dwoFile,
           ltoIndexingFile,
@@ -183,6 +187,7 @@ public enum CompileBuildVariables {
       String sourceFile,
       String outputFile,
       String gcnoFile,
+      String indexStorePath,
       boolean isUsingFission,
       String dwoFile,
       String ltoIndexingFile,
@@ -214,6 +219,7 @@ public enum CompileBuildVariables {
         sourceFile,
         outputFile,
         gcnoFile,
+        indexStorePath,
         isUsingFission,
         dwoFile,
         ltoIndexingFile,
@@ -241,6 +247,7 @@ public enum CompileBuildVariables {
       String sourceFile,
       String outputFile,
       String gcnoFile,
+      String indexStorePath,
       boolean isUsingFission,
       String dwoFile,
       String ltoIndexingFile,
@@ -282,6 +289,7 @@ public enum CompileBuildVariables {
         outputFile,
         gcnoFile,
         dwoFile,
+        indexStorePath,
         isUsingFission,
         ltoIndexingFile,
         userCompileFlags,
@@ -298,6 +306,7 @@ public enum CompileBuildVariables {
       String outputFile,
       String gcnoFile,
       String dwoFile,
+      String indexStorePath,
       boolean isUsingFission,
       String ltoIndexingFile,
       Iterable<String> userCompileFlags,
@@ -330,6 +339,10 @@ public enum CompileBuildVariables {
 
     if (dwoFile != null) {
       buildVariables.addStringVariable(PER_OBJECT_DEBUG_INFO_FILE.getVariableName(), dwoFile);
+    }
+
+    if (indexStorePath != null) {
+      buildVariables.addStringVariable(INDEX_STORE_PATH.getVariableName(), indexStorePath);
     }
 
     if (isUsingFission) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -245,6 +245,7 @@ public class CppCompileAction extends AbstractAction
       @Nullable Artifact gcnoFile,
       @Nullable Artifact dwoFile,
       @Nullable Artifact ltoIndexingFile,
+      @Nullable Artifact indexStorePath,
       ActionEnvironment env,
       CcCompilationContext ccCompilationContext,
       CoptsFilter coptsFilter,
@@ -258,7 +259,7 @@ public class CppCompileAction extends AbstractAction
     super(
         owner,
         IterablesChain.concat(mandatoryInputs, inputsForInvalidation),
-        CollectionUtils.asSetWithoutNulls(outputFile, dotdFile, gcnoFile, dwoFile, ltoIndexingFile),
+        CollectionUtils.asSetWithoutNulls(outputFile, dotdFile, gcnoFile, dwoFile, ltoIndexingFile, indexStorePath),
         env);
     Preconditions.checkArgument(!shouldPruneModules || shouldScanIncludes);
     this.outputFile = Preconditions.checkNotNull(outputFile);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
@@ -61,6 +61,7 @@ public class CppCompileActionBuilder {
   @Nullable private PathFragment tempOutputFile;
   private Artifact dotdFile;
   private Artifact gcnoFile;
+  @Nullable Artifact indexStore;
   private CcCompilationContext ccCompilationContext = CcCompilationContext.EMPTY;
   private final List<String> pluginOpts = new ArrayList<>();
   private CoptsFilter coptsFilter = CoptsFilter.alwaysPasses();
@@ -121,6 +122,7 @@ public class CppCompileActionBuilder {
     this.tempOutputFile = other.tempOutputFile;
     this.dotdFile = other.dotdFile;
     this.gcnoFile = other.gcnoFile;
+    this.indexStore = other.indexStore;
     this.ccCompilationContext = other.ccCompilationContext;
     this.pluginOpts.addAll(other.pluginOpts);
     this.coptsFilter = other.coptsFilter;
@@ -321,6 +323,7 @@ public class CppCompileActionBuilder {
               gcnoFile,
               dwoFile,
               ltoIndexingFile,
+              indexStore,
               env,
               ccCompilationContext,
               coptsFilter,
@@ -489,6 +492,11 @@ public class CppCompileActionBuilder {
 
   public CppCompileActionBuilder setDwoFile(Artifact dwoFile) {
     this.dwoFile = dwoFile;
+    return this;
+  }
+
+  public CppCompileActionBuilder setIndexStore(Artifact indexStore) {
+    this.indexStore = indexStore;
     return this;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -698,4 +698,8 @@ public final class CppConfiguration extends BuildConfiguration.Fragment
   public boolean loadCcRulesFromBzl() {
     return cppOptions.loadCcRulesFromBzl;
   }
+
+  public boolean indexWhileBuilding() {
+    return cppOptions.indexWhileBuilding;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkstampCompileHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkstampCompileHelper.java
@@ -160,6 +160,7 @@ public class CppLinkstampCompileHelper {
         sourceFile.getExecPathString(),
         outputFile.getExecPathString(),
         /* gcnoFile= */ null,
+        null,
         /* isUsingFission= */ false,
         /* dwoFile= */ null,
         /* ltoIndexingFile= */ null,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkstampCompileHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkstampCompileHelper.java
@@ -160,7 +160,7 @@ public class CppLinkstampCompileHelper {
         sourceFile.getExecPathString(),
         outputFile.getExecPathString(),
         /* gcnoFile= */ null,
-        null,
+        /* indexStorePath= */null,
         /* isUsingFission= */ false,
         /* dwoFile= */ null,
         /* ltoIndexingFile= */ null,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -918,6 +918,15 @@ public class CppOptions extends FragmentOptions {
               + "the Starlark rules instead https://github.com/bazelbuild/rules_cc")
   public boolean loadCcRulesFromBzl;
 
+  @Option(
+          name = "index_while_building",
+          defaultValue = "false",
+          documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+          effectTags = {OptionEffectTag.ACTION_COMMAND_LINES, OptionEffectTag.AFFECTS_OUTPUTS},
+          metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+          help = "If enabled, C compile actions will output index data using the -index-store-path flag.")
+  public boolean indexWhileBuilding;
+
   @Override
   public FragmentOptions getHost() {
     CppOptions host = (CppOptions) getDefault();
@@ -976,6 +985,7 @@ public class CppOptions extends FragmentOptions {
     host.disableStaticCcToolchains = disableStaticCcToolchains;
     host.disableNoCopts = disableNoCopts;
     host.loadCcRulesFromBzl = loadCcRulesFromBzl;
+    host.indexWhileBuilding = indexWhileBuilding;
 
     // Save host options for further use.
     host.hostCoptList = hostCoptList;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
@@ -413,6 +413,8 @@ public class CppRuleClasses {
 
   public static final String COMPIILER_PARAM_FILE = "compiler_param_file";
 
+  public static final String INDEX_WHILE_BUILDING = "index_while_building";
+
   /** Ancestor for all rules that do include scanning. */
   public static final class CcIncludeScanningRule implements RuleDefinition {
     @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/FakeCppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/FakeCppCompileAction.java
@@ -105,6 +105,7 @@ public class FakeCppCompileAction extends CppCompileAction {
         /* gcnoFile=*/ null,
         /* dwoFile=*/ null,
         /* ltoIndexingFile=*/ null,
+        null,
         env,
         // We only allow inclusion of header files explicitly declared in
         // "srcs", so we only use declaredIncludeSrcs, not declaredIncludeDirs.

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/FakeCppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/FakeCppCompileAction.java
@@ -105,7 +105,7 @@ public class FakeCppCompileAction extends CppCompileAction {
         /* gcnoFile=*/ null,
         /* dwoFile=*/ null,
         /* ltoIndexingFile=*/ null,
-        null,
+        /* indexStorePath= */null,
         env,
         // We only allow inclusion of header files explicitly declared in
         // "srcs", so we only use declaredIncludeSrcs, not declaredIncludeDirs.

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5281,7 +5281,7 @@ def _impl(ctx):
                     ],
                     flag_groups = [
                         flag_group(
-                            flags = ["-index-store-path", "%{index_store_path}"],
+                            flags = ["-index-store-path", "%{index_store_path}", "-index-ignore-system-symbols"],
                             expand_if_available = "index_store_path",
                         ),
                     ],

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5268,8 +5268,8 @@ def _impl(ctx):
         provides = ["profile"],
     )
 
-    index_store_feature = feature(
-            name = "index_store",
+    index_while_building_feature = feature(
+            name = "index_while_building",
             enabled = True,
             flag_sets = [
                 flag_set(
@@ -5475,7 +5475,7 @@ def _impl(ctx):
             include_paths_feature,
             sysroot_feature,
             dependency_file_feature,
-            index_store_feature,
+            index_while_building_feature,
             pic_feature,
             per_object_debug_info_feature,
             preprocessor_defines_feature,

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5268,6 +5268,29 @@ def _impl(ctx):
         provides = ["profile"],
     )
 
+    index_store_feature = feature(
+            name = "index_store",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.objc_compile,
+                        ACTION_NAMES.objcpp_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = ["-index-store-path", "%{index_store_path}"],
+                            expand_if_available = "index_store_path",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+
+
     if (ctx.attr.cpu == "darwin_x86_64"):
         link_cocoa_feature = feature(
             name = "link_cocoa",
@@ -5452,6 +5475,7 @@ def _impl(ctx):
             include_paths_feature,
             sysroot_feature,
             dependency_file_feature,
+            index_store_feature,
             pic_feature,
             per_object_debug_info_feature,
             preprocessor_defines_feature,

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5281,7 +5281,7 @@ def _impl(ctx):
                     ],
                     flag_groups = [
                         flag_group(
-                            flags = ["-index-store-path", "%{index_store_path}", "-index-ignore-system-symbols"],
+                            flags = ["-index-store-path", "%{index_store_path}"],
                             expand_if_available = "index_store_path",
                         ),
                     ],


### PR DESCRIPTION
First pass at adding index store output to `objc_library`. This currently works, something that is not clear is how this declared output maps to an output group (does it even?). In other words, how do we get the path using an aspects pass?