### PR TITLE
Sync accepts parameters to filter repositories that should be synced

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/sync.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/sync.txt
@@ -1,5 +1,5 @@
 
-Usage: %{product} %{command} [<option> ...]
+Usage: %{product} %{command} [<option> ...] [<repositories> ...]
 
 Ensures that all Skylark repository rules of the top-level WORKSPACE
 file are called.


### PR DESCRIPTION
Allow re-fetch specific repositories. Use as `bazel sync [<repo_name>, ...]`, e.g. `bazel sync rules_cc`.