### PR TITLE
Use label for netrc file in http rule

### DIFF
--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -42,7 +42,7 @@ load(
 def _get_auth(ctx, urls):
     """Given the list of URLs obtain the correct auth dict."""
     if ctx.attr.netrc:
-        netrc = read_netrc(ctx, ctx.attr.netrc)
+        netrc = read_netrc(ctx, ctx.path(ctx.attr.netrc))
         return use_netrc(netrc, urls)
 
     if "HOME" in ctx.os.environ:
@@ -185,8 +185,8 @@ to omit the SHA-256 as remote files can change._ At best omitting this
 field will make your build non-hermetic. It is optional to make development
 easier but should be set before shipping.""",
     ),
-    "netrc": attr.string(
-        doc = "Location of the .netrc file to use for authentication",
+    "netrc": attr.label(
+        doc = "A .netrc file to use for authentication",
     ),
     "canonical_id": attr.string(
         doc = """A canonical id of the archive downloaded.
@@ -364,8 +364,8 @@ easier but should be set before shipping.""",
 Each entry must be a file, http or https URL. Redirections are followed.
 Authentication is not supported.""",
     ),
-    "netrc": attr.string(
-        doc = "Location of the .netrc file to use for authentication",
+    "netrc": attr.label(
+        doc = "A .netrc file to use for authentication",
     ),
 }
 


### PR DESCRIPTION
Currently it is not possible to use a file from the current repo as netrc file, unless the absolute path is known. Using a label as an attribute make it more versatile.