### PR TITLE
Add index store to a dedicated CppCompilationOutputs field and output group

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -800,6 +800,11 @@ public final class CcCompilationHelper {
     outputGroupsBuilder.putAll(
         CcCommon.createSaveFeatureStateArtifacts(
             cppConfiguration, featureConfiguration, ruleContext));
+    outputGroupsBuilder.put(
+        "cc_index_store",
+        NestedSetBuilder.<Artifact>stableOrder()
+            .addAll(ccCompilationOutputs.getIndexStoreFiles()).build()
+    );
     return outputGroupsBuilder.build();
   }
 
@@ -1877,6 +1882,10 @@ public final class CcCompilationHelper {
           // Host targets don't produce .dwo files.
           result.addPicDwoFile(dwoFile);
         }
+
+        if (indexStore != null) {
+          result.addIndexStore(indexStore);
+        }
       }
 
       if (generateNoPicAction) {
@@ -1954,6 +1963,10 @@ public final class CcCompilationHelper {
         if (noPicDwoFile != null) {
           // Host targets don't produce .dwo files.
           result.addDwoFile(noPicDwoFile);
+        }
+
+        if (indexStore != null) {
+          result.addIndexStore(indexStore);
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationOutputs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationOutputs.java
@@ -70,6 +70,11 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
    */
   private final ImmutableList<Artifact> headerTokenFiles;
 
+  /**
+   * All the .index files generated during compilation
+   */
+  private final ImmutableList<Artifact> indexStore;
+
   private CcCompilationOutputs(
       ImmutableList<Artifact> objectFiles,
       ImmutableList<Artifact> picObjectFiles,
@@ -77,7 +82,8 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
       ImmutableList<Artifact> dwoFiles,
       ImmutableList<Artifact> picDwoFiles,
       NestedSet<Artifact> temps,
-      ImmutableList<Artifact> headerTokenFiles) {
+      ImmutableList<Artifact> headerTokenFiles,
+      ImmutableList<Artifact> indexStore) {
     this.objectFiles = objectFiles;
     this.picObjectFiles = picObjectFiles;
     this.ltoCompilationContext = ltoCompilationContext;
@@ -85,6 +91,7 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
     this.picDwoFiles = picDwoFiles;
     this.temps = temps;
     this.headerTokenFiles = headerTokenFiles;
+    this.indexStore = indexStore;
   }
 
   /**
@@ -138,6 +145,13 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
   }
 
   /**
+   * Returns and unmodifiable view of the .index files set.
+   */
+  public ImmutableList<Artifact> getIndexStoreFiles() {
+    return indexStore;
+  }
+
+  /**
    * Returns an unmodifiable view of the .pic.dwo files set.
    */
   public ImmutableList<Artifact> getPicDwoFiles() {
@@ -183,6 +197,7 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
     private final Set<Artifact> picDwoFiles = new LinkedHashSet<>();
     private final NestedSetBuilder<Artifact> temps = NestedSetBuilder.stableOrder();
     private final Set<Artifact> headerTokenFiles = new LinkedHashSet<>();
+    private Set<Artifact> indexStore = new LinkedHashSet<>();
 
     private Builder() {
       // private to avoid class initialization deadlock between this class and its outer class
@@ -196,7 +211,8 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
           ImmutableList.copyOf(dwoFiles),
           ImmutableList.copyOf(picDwoFiles),
           temps.build(),
-          ImmutableList.copyOf(headerTokenFiles));
+          ImmutableList.copyOf(headerTokenFiles),
+          ImmutableList.copyOf(indexStore));
     }
 
     public Builder merge(CcCompilationOutputs outputs) {
@@ -253,6 +269,11 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
       }
 
       Iterables.addAll(picObjectFiles, artifacts);
+      return this;
+    }
+
+    public Builder addIndexStore(Artifact artifact){
+      indexStore.add(artifact);
       return this;
     }
 


### PR DESCRIPTION
Add the index store files to a dedicated output group for an easier retrieval in Starlark.