### PR TITLE
Add option to execute multiple test runs sequentially

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -361,6 +361,7 @@ public final class TestActionBuilder {
     // Use 1-based indices for user friendliness.
     for (int shard = 0; shard < shardRuns; shard++) {
       String shardDir = shardRuns > 1 ? String.format("shard_%d_of_%d", shard + 1, shards) : null;
+      TestRunnerAction lastTestRun = null;
       for (int run = 0; run < runsPerTest; run++) {
         PathFragment dir;
         if (runsPerTest > 1) {
@@ -419,7 +420,10 @@ public final class TestActionBuilder {
         TestRunnerAction testRunnerAction =
             new TestRunnerAction(
                 ruleContext.getActionOwner(),
-                inputs,
+                testConfiguration.runsPerTestAreSequential() && lastTestRun != null ?
+                    NestedSetBuilder.fromNestedSet(inputs)
+                        .add(lastTestRun.getCacheStatusArtifact()).build() :
+                    inputs,
                 testRunfilesSupplier,
                 testActionExecutable,
                 testXmlGeneratorExecutable,
@@ -442,6 +446,7 @@ public final class TestActionBuilder {
                 cancelConcurrentTests,
                 tools.build());
 
+        lastTestRun = testRunnerAction;
         testOutputs.addAll(testRunnerAction.getSpawnOutputs());
         testOutputs.addAll(testRunnerAction.getOutputs());
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -199,6 +199,16 @@ public class TestConfiguration extends Fragment {
     public List<PerLabelOptions> runsPerTest;
 
     @Option(
+        name = "sequential_runs_per_test",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        help =
+            "If true, multiple runs of the same tests are executed sequentially, that is "
+                + "there is never a time when there are concurrent runs of the same test.")
+    public boolean runsPerTestAreSequential;
+
+    @Option(
         name = "runs_per_test_detects_flakes",
         defaultValue = "false",
         documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
@@ -352,6 +362,10 @@ public class TestConfiguration extends Fragment {
       }
     }
     return 1;
+  }
+
+  public boolean runsPerTestAreSequential() {
+    return options.runsPerTestAreSequential;
   }
 
   public boolean runsPerTestDetectsFlakes() {


### PR DESCRIPTION
Feed the output of the previous test run into the next one to force them to be executed sequentially. Hacky, but seems to work fine.