### PR TITLE
HttpCacheClient queries remote cache for missing blobs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/http/FindMissingDigestCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/FindMissingDigestCommand.java
@@ -1,0 +1,37 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.http;
+
+import com.google.common.base.Preconditions;
+import java.net.URI;
+
+/** Object sent through the channel pipeline to query for existence of digest. */
+final class FindMissingDigestCommand {
+
+  private final URI uri;
+  private final String hash;
+
+  protected FindMissingDigestCommand(URI uri, String hash) {
+    this.uri = Preconditions.checkNotNull(uri);
+    this.hash = Preconditions.checkNotNull(hash);
+  }
+
+  public URI uri() {
+    return uri;
+  }
+
+  public String hash() {
+    return hash;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/http/FindMissingDigestTimeoutException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/FindMissingDigestTimeoutException.java
@@ -1,0 +1,28 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote.http;
+
+import java.io.IOException;
+
+final class FindMissingDigestTimeoutException extends IOException {
+
+  FindMissingDigestTimeoutException(String url) {
+    super(buildMessage(url));
+  }
+
+  private static String buildMessage(String url) {
+    return String.format("Querying for availability of '%s' timed out. It will be uploaded.", url);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -352,6 +352,54 @@ public final class HttpCacheClient implements RemoteCacheClient {
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
+  private Future<Channel> acquireFindMissingDigestChannel() {
+    Promise<Channel> channelReady = eventLoop.next().newPromise();
+    channelPool
+        .acquire()
+        .addListener(
+            (Future<Channel> channelAcquired) -> {
+              if (!channelAcquired.isSuccess()) {
+                channelReady.setFailure(channelAcquired.cause());
+                return;
+              }
+
+              try {
+                Channel ch = channelAcquired.getNow();
+                ChannelPipeline p = ch.pipeline();
+
+                if (!isChannelPipelineEmpty(p)) {
+                  channelReady.setFailure(
+                      new IllegalStateException("Channel pipeline is not empty."));
+                  return;
+                }
+
+                p.addFirst(
+                    "timeout-handler",
+                    new IdleTimeoutHandler(timeoutSeconds, ReadTimeoutException.INSTANCE));
+                p.addLast(new HttpClientCodec());
+                synchronized (credentialsLock) {
+                  p.addLast(new HttpFindMissingDigestHandler(creds, extraHttpHeaders));
+                }
+
+                if (!ch.eventLoop().inEventLoop()) {
+                  // If addLast is called outside an event loop, then it doesn't complete until the
+                  // event loop is run again. In that case, a message sent to the last handler gets
+                  // delivered to the last non-pending handler, which will most likely end up
+                  // throwing UnsupportedMessageTypeException. Therefore, we only complete the
+                  // promise in the event loop.
+                  ch.eventLoop().execute(() -> channelReady.setSuccess(ch));
+                } else {
+                  channelReady.setSuccess(ch);
+                }
+              } catch (Throwable t) {
+                channelReady.setFailure(t);
+              }
+            });
+
+    return channelReady;
+  }
+
+  @SuppressWarnings("FutureReturnValueIgnored")
   private void releaseUploadChannel(Channel ch) {
     if (ch.isOpen()) {
       try {
@@ -361,6 +409,22 @@ public final class HttpCacheClient implements RemoteCacheClient {
         ch.pipeline().remove(HttpRequestEncoder.class);
         ch.pipeline().remove(ChunkedWriteHandler.class);
         ch.pipeline().remove(HttpUploadHandler.class);
+      } catch (NoSuchElementException e) {
+        // If the channel is in the process of closing but not yet closed, some handlers could have
+        // been removed and would cause NoSuchElement exceptions to be thrown. Because handlers are
+        // removed in reverse-order, if we get a NoSuchElement exception, the following handlers
+        // should have been removed.
+      }
+    }
+    channelPool.release(ch);
+  }
+
+  private void releaseFindMissingDigestChannel(Channel ch) {
+    if (ch.isOpen()) {
+      try {
+        ch.pipeline().remove(IdleTimeoutHandler.class);
+        ch.pipeline().remove(HttpClientCodec.class);
+        ch.pipeline().remove(HttpFindMissingDigestHandler.class);
       } catch (NoSuchElementException e) {
         // If the channel is in the process of closing but not yet closed, some handlers could have
         // been removed and would cause NoSuchElement exceptions to be thrown. Because handlers are
@@ -509,6 +573,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
                       (f) -> {
                         try {
                           if (f.isSuccess()) {
+                            storedBlobs.putIfAbsent(
+                                (casDownload ? CAS_PREFIX : AC_PREFIX) + digest.getHash(), true);
                             outerF.set(null);
                           } else {
                             Throwable cause = f.cause();
@@ -525,6 +591,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
                                 getAfterCredentialRefresh(downloadCmd, outerF);
                                 return;
                               } else if (cacheMiss(response.status())) {
+                                storedBlobs.remove(
+                                    (casDownload ? CAS_PREFIX : AC_PREFIX) + digest.getHash());
                                 outerF.setException(new CacheNotFoundException(digest));
                                 return;
                               }
@@ -652,9 +720,65 @@ public final class HttpCacheClient implements RemoteCacheClient {
     return Futures.immediateFuture(null);
   }
 
+  private ListenableFuture<Digest> findMissingDigest(
+      Digest digest, SettableFuture<Digest> future, boolean retryOnTokenExpired) {
+    if (storedBlobs.containsKey(CAS_PREFIX + digest.getHash())) {
+      // We've already pushed this artifact before, we expect it to be in cache
+      // so we save us one request.
+      return Futures.immediateFuture(null);
+    }
+    acquireFindMissingDigestChannel()
+        .addListener(
+            (Future<Channel> chF) -> {
+              if (!chF.isSuccess()) {
+                future.set(digest);
+                return;
+              }
+              Channel ch = chF.getNow();
+              future.addListener(
+                  () -> releaseFindMissingDigestChannel(ch),
+                  MoreExecutors.directExecutor());
+              ch.writeAndFlush(new FindMissingDigestCommand(uri, digest.getHash()))
+                  .addListener(
+                      (f) -> {
+                        if (f.isSuccess()) {
+                          storedBlobs.putIfAbsent(CAS_PREFIX + digest.getHash(), true);
+                          future.set(null);
+                        } else {
+                          if (retryOnTokenExpired && f.cause() instanceof HttpException) {
+                            HttpResponse response = ((HttpException) f.cause()).response();
+                            if (authTokenExpired(response)) {
+                              refreshCredentials();
+                              findMissingDigest(digest, future, false);
+                              return;
+                            }
+                          }
+                          future.set(digest);
+                        }
+                      });
+            });
+    return future;
+  }
+
   @Override
   public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(Iterable<Digest> digests) {
-    return Futures.immediateFuture(ImmutableSet.copyOf(digests));
+    ImmutableList.Builder<ListenableFuture<Digest>> queries = ImmutableList.builder();
+    for (Digest digest : digests) {
+      queries.add(findMissingDigest(digest, SettableFuture.create(), true));
+    }
+
+    return Futures.transformAsync(
+        Futures.allAsList(queries.build()),
+        (f) -> {
+          ImmutableSet.Builder<Digest> missingDigests = ImmutableSet.builder();
+          for (Digest digest : f) {
+            if (digest != null) {
+              missingDigests.add(digest);
+            }
+          }
+          return Futures.immediateFuture(missingDigests.build());
+        },
+        MoreExecutors.directExecutor());
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpFindMissingDigestHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpFindMissingDigestHandler.java
@@ -1,0 +1,126 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.http;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.auth.Credentials;
+import com.google.common.collect.ImmutableList;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpChunkedInput;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.stream.ChunkedStream;
+import io.netty.handler.timeout.ReadTimeoutException;
+import io.netty.handler.timeout.WriteTimeoutException;
+import io.netty.util.internal.StringUtil;
+import java.io.IOException;
+import java.util.Map.Entry;
+
+/** ChannelHandler for find missing digests api. */
+final class HttpFindMissingDigestHandler extends AbstractHttpHandler<HttpResponse> {
+
+  String path;
+
+  public HttpFindMissingDigestHandler(
+      Credentials credentials, ImmutableList<Entry<String, String>> extraHttpHeaders) {
+    super(credentials, extraHttpHeaders);
+  }
+
+  @SuppressWarnings("FutureReturnValueIgnored")
+  @Override
+  protected void channelRead0(ChannelHandlerContext ctx, HttpResponse response) {
+    if (!response.decoderResult().isSuccess()) {
+      failAndClose(new IOException("Failed to parse the HTTP response."), ctx);
+      return;
+    }
+    try {
+      checkState(userPromise != null, "response before request");
+      if (response.status().equals(HttpResponseStatus.OK)) {
+        succeedAndResetUserPromise();
+      } else {
+        failAndResetUserPromise(new HttpException(response, null, null));
+      }
+    } finally {
+      if (!HttpUtil.isKeepAlive(response)) {
+        ctx.close();
+      }
+    }
+  }
+
+  @Override
+  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+      throws Exception {
+    checkState(userPromise == null, "handler can't be shared between pipelines.");
+    userPromise = promise;
+    if (!(msg instanceof FindMissingDigestCommand)) {
+      failAndResetUserPromise(
+          new IllegalArgumentException(
+              "Unsupported message type: " + StringUtil.simpleClassName(msg)));
+      return;
+    }
+    FindMissingDigestCommand cmd = (FindMissingDigestCommand) msg;
+    path = constructPath(cmd.uri(), cmd.hash(), true);
+    HttpRequest request = buildRequest(path, constructHost(cmd.uri()));
+    addCredentialHeaders(request, cmd.uri());
+    addExtraRemoteHeaders(request);
+    addUserAgentHeader(request);
+    ctx.writeAndFlush(request)
+        .addListener(
+            (f) -> {
+              if (!f.isSuccess()) {
+                failAndClose(f.cause(), ctx);
+              }
+            });
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable t) {
+    if (t instanceof ReadTimeoutException) {
+      super.exceptionCaught(ctx, new FindMissingDigestTimeoutException(path));
+    } else if (t instanceof TooLongFrameException) {
+      super.exceptionCaught(ctx, new IOException(t));
+    } else {
+      super.exceptionCaught(ctx, t);
+    }
+  }
+
+  private HttpRequest buildRequest(String path, String host) {
+    HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.HEAD, path);
+    request.headers().set(HttpHeaderNames.HOST, host);
+    request.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+    return request;
+  }
+
+  @SuppressWarnings("FutureReturnValueIgnored")
+  private void failAndClose(Throwable t, ChannelHandlerContext ctx) {
+    try {
+      failAndResetUserPromise(t);
+    } finally {
+      ctx.close();
+    }
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -32,6 +32,7 @@ import com.google.api.client.util.Preconditions;
 import com.google.auth.Credentials;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.testutil.MoreAsserts.ThrowingRunnable;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -41,6 +42,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandler.Sharable;
@@ -65,6 +67,7 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpServerCodec;
@@ -86,6 +89,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntFunction;
 import javax.annotation.Nullable;
 import org.junit.Test;
@@ -290,6 +294,80 @@ public class HttpCacheClientTest {
       throws Exception {
     return createHttpBlobStore(
         serverChannel, timeoutSeconds, /* remoteVerifyDownloads= */ true, creds);
+  }
+
+  @Test
+  public void testFindMissingDigestsUnsupported() throws Exception {
+    ServerChannel server = null;
+    try {
+      server =
+          testServer.start(
+              new SimpleChannelInboundHandler<FullHttpRequest>() {
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) {
+                  FullHttpResponse response =
+                      new DefaultFullHttpResponse(
+                          HttpVersion.HTTP_1_1, HttpResponseStatus.METHOD_NOT_ALLOWED);
+                  ctx.writeAndFlush(response);
+                }
+              });
+      HttpCacheClient blobStore = createHttpBlobStore(server, 1, null);
+      ImmutableSet<Digest> digests = ImmutableSet.of(DIGEST_UTIL.compute(new byte[0]));
+      assertThat(blobStore.findMissingDigests(digests).get()).isEqualTo(digests);
+    } finally {
+      testServer.stop(server);
+    }
+  }
+
+  @Test
+  public void testFindMissingDigests() throws Exception {
+    ServerChannel server = null;
+    AtomicInteger headCounter = new AtomicInteger(0);
+    Digest zero = DIGEST_UTIL.compute(new byte[0]);
+    Digest a = DIGEST_UTIL.compute(new byte[] {'a'});
+    Digest b = DIGEST_UTIL.compute(new byte[] {'b', 'b'});
+    Digest c = DIGEST_UTIL.compute(new byte[] {'c', 'c', 'c'});
+    ConcurrentHashMap<String, byte[]> cache = new ConcurrentHashMap<>();
+    cache.put("/" + HttpCacheClient.CAS_PREFIX + zero.getHash(), new byte[0]);
+    cache.put("/" + HttpCacheClient.CAS_PREFIX + a.getHash(), new byte[0]);
+    cache.put("/" + HttpCacheClient.CAS_PREFIX + b.getHash(), new byte[0]);
+    try {
+      server =
+          testServer.start(
+              new HttpCacheServerHandler(cache) {
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
+                  if (request.method().equals(HttpMethod.HEAD)) {
+                    headCounter.incrementAndGet();
+                    FullHttpResponse response;
+                    if (cache.containsKey(request.uri())) {
+                      response =
+                          new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+                    } else {
+                      response =
+                          new DefaultFullHttpResponse(
+                              HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
+                    }
+                    ctx.writeAndFlush(response);
+                  } else {
+                    super.channelRead0(ctx, request);
+                  }
+                }
+              });
+      HttpCacheClient blobStore = createHttpBlobStore(server, 1, false, null);
+
+      blobStore.downloadBlob(a, new ByteArrayOutputStream()).get();
+      assertThat(blobStore.findMissingDigests(ImmutableSet.of(zero, a, c)).get())
+          .isEqualTo(ImmutableSet.of(c));
+      assertThat(headCounter.get()).isEqualTo(2);
+
+      blobStore.uploadBlob(c, ByteString.copyFrom(c.toByteArray()));
+      assertThat(blobStore.findMissingDigests(ImmutableSet.of(zero, a, b)).get())
+          .isEqualTo(ImmutableSet.of());
+      assertThat(headCounter.get()).isEqualTo(3);
+    } finally {
+      testServer.stop(server);
+    }
   }
 
   @Test


### PR DESCRIPTION
Implement `findMissingDigests` in `HttpCacheClient` to prevent a file from being uploaded if the remote already have it.