### PR TITLE
Add retry logic for HTTP cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
@@ -113,7 +113,8 @@ public final class RemoteCacheClientFactory {
               options.remoteVerifyDownloads,
               ImmutableList.copyOf(options.remoteHeaders),
               digestUtil,
-              creds);
+              creds,
+              HttpCacheClient.newRetrier(options));
         } else {
           throw new Exception("Remote cache proxy unsupported: " + options.remoteProxy);
         }
@@ -125,7 +126,8 @@ public final class RemoteCacheClientFactory {
             options.remoteVerifyDownloads,
             ImmutableList.copyOf(options.remoteHeaders),
             digestUtil,
-            creds);
+            creds,
+            HttpCacheClient.newRetrier(options));
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -265,19 +265,35 @@ public class Retrier {
    * backoff.
    */
   public <T> ListenableFuture<T> executeAsync(AsyncCallable<T> call, Backoff backoff) {
+    State circuitState = circuitBreaker.state();
+    if (circuitState.equals(State.REJECT_CALLS)) {
+      return Futures.immediateFailedFuture(new CircuitBreakerException());
+    }
     try {
-      return Futures.catchingAsync(
+      ListenableFuture<T> future = Futures.transformAsync(
           call.call(),
+          (f) -> {
+            circuitBreaker.recordSuccess();
+            return Futures.immediateFuture(f);
+          },
+          MoreExecutors.directExecutor()
+      );
+      return Futures.catchingAsync(
+          future,
           Exception.class,
-          t -> onExecuteAsyncFailure(t, call, backoff),
+          t -> onExecuteAsyncFailure(t, call, backoff, circuitState),
           MoreExecutors.directExecutor());
     } catch (Exception e) {
-      return onExecuteAsyncFailure(e, call, backoff);
+      return onExecuteAsyncFailure(e, call, backoff, circuitState);
     }
   }
 
   private <T> ListenableFuture<T> onExecuteAsyncFailure(
-      Exception t, AsyncCallable<T> call, Backoff backoff) {
+      Exception t, AsyncCallable<T> call, Backoff backoff, State circuitState) {
+    circuitBreaker.recordFailure();
+    if (circuitState.equals(State.TRIAL_CALL)) {
+      return Futures.immediateFailedFuture(t);
+    }
     long waitMillis = backoff.nextDelayMillis();
     if (waitMillis >= 0 && isRetriable(t)) {
       try {

--- a/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -18,7 +18,9 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib:build-base",
+        "//src/main/java/com/google/devtools/build/lib/remote:Retrier",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -23,8 +23,11 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.devtools.build.lib.remote.RemoteRetrier;
+import com.google.devtools.build.lib.remote.Retrier;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.vfs.Path;
@@ -77,11 +80,13 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -90,6 +95,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
 
 /**
  * Implementation of {@link RemoteCacheClient} that can talk to a HTTP/1.1 backend.
@@ -124,6 +130,10 @@ public final class HttpCacheClient implements RemoteCacheClient {
 
   private static Logger logger = Logger.getLogger(HttpCacheClient.class.getName());
 
+  private static Pattern RETRYABLE_ERROR_MESSAGE = Pattern.compile(
+      "^.*(?:(?:connection.*(?:reset|closed|abort|broken)|broken.*pipe)|(?:(?:connection|operation|download|upload|read|write).*time.?\\s?out)).*$",
+      Pattern.CASE_INSENSITIVE);
+
   private final ConcurrentHashMap<String, Boolean> storedBlobs = new ConcurrentHashMap<>();
 
   private final EventLoopGroup eventLoop;
@@ -136,6 +146,7 @@ public final class HttpCacheClient implements RemoteCacheClient {
   private final DigestUtil digestUtil;
 
   private final Object closeLock = new Object();
+  private final RemoteRetrier retrier;
 
   @GuardedBy("closeLock")
   private boolean isClosed;
@@ -155,7 +166,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
       boolean verifyDownloads,
       ImmutableList<Entry<String, String>> extraHttpHeaders,
       DigestUtil digestUtil,
-      @Nullable final Credentials creds)
+      @Nullable final Credentials creds,
+      @Nullable RemoteRetrier retrier)
       throws Exception {
     return new HttpCacheClient(
         NioEventLoopGroup::new,
@@ -167,7 +179,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
         extraHttpHeaders,
         digestUtil,
         creds,
-        null);
+        null,
+        retrier);
   }
 
   public static HttpCacheClient create(
@@ -178,7 +191,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
       boolean verifyDownloads,
       ImmutableList<Entry<String, String>> extraHttpHeaders,
       DigestUtil digestUtil,
-      @Nullable final Credentials creds)
+      @Nullable final Credentials creds,
+      @Nullable RemoteRetrier retrier)
       throws Exception {
 
     if (KQueue.isAvailable()) {
@@ -192,7 +206,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
           extraHttpHeaders,
           digestUtil,
           creds,
-          domainSocketAddress);
+          domainSocketAddress,
+          retrier);
     } else if (Epoll.isAvailable()) {
       return new HttpCacheClient(
           EpollEventLoopGroup::new,
@@ -204,7 +219,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
           extraHttpHeaders,
           digestUtil,
           creds,
-          domainSocketAddress);
+          domainSocketAddress,
+          retrier);
     } else {
       throw new Exception("Unix domain sockets are unsupported on this platform");
     }
@@ -220,7 +236,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
       ImmutableList<Entry<String, String>> extraHttpHeaders,
       DigestUtil digestUtil,
       @Nullable final Credentials creds,
-      @Nullable SocketAddress socketAddress)
+      @Nullable SocketAddress socketAddress,
+      @Nullable RemoteRetrier retrier)
       throws Exception {
     useTls = uri.getScheme().equals("https");
     if (uri.getPort() == -1) {
@@ -288,6 +305,48 @@ public final class HttpCacheClient implements RemoteCacheClient {
     this.extraHttpHeaders = extraHttpHeaders;
     this.verifyDownloads = verifyDownloads;
     this.digestUtil = digestUtil;
+    this.retrier = retrier != null ? retrier : newRetrier(null);
+  }
+
+  public static RemoteRetrier newRetrier(RemoteOptions options) {
+    if (options == null || options.remoteMaxRetryAttempts <= 0) {
+      return new RemoteRetrier(
+          () -> Retrier.RETRIES_DISABLED,
+          (Exception e) -> false,
+          MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1)),
+          Retrier.ALLOW_ALL_CALLS);
+    }
+    return new RemoteRetrier(
+        () -> new RemoteRetrier.ExponentialBackoff(options),
+        (Exception e) -> shouldRetry(e),
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1)),
+        Retrier.ALLOW_ALL_CALLS);
+  }
+
+  private static boolean shouldRetry(Exception e) {
+    if (e instanceof HttpException) {
+      HttpResponse response = ((HttpException) e).response();
+      if (response.status().equals(HttpResponseStatus.INTERNAL_SERVER_ERROR)
+          || response.status().equals(HttpResponseStatus.BAD_GATEWAY)
+          || response.status().equals(HttpResponseStatus.SERVICE_UNAVAILABLE)) {
+        logger.info(String.format("Retrying: HttpException: %s.", response.status().toString()));
+        return true;
+      }
+    } else if (e instanceof ClosedChannelException
+        || e instanceof SSLException
+        || e instanceof DownloadTimeoutException
+        || e instanceof UploadTimeoutException) {
+      logger.info(String.format("Retrying: %s: %s.", e.getClass().getSimpleName(), e.getMessage()));
+      return true;
+    } else if (e instanceof IOException) {
+      String message = e.getMessage();
+      if (RETRYABLE_ERROR_MESSAGE.asPredicate().test(message)) {
+        logger.info(String.format("Retrying: IOException: %s.", message));
+        return true;
+      }
+    }
+    logger.warning(String.format("Failed: %s: %s.", e.getClass().getSimpleName(), e.getMessage()));
+    return false;
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
@@ -515,7 +574,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
     final HashingOutputStream hashOut =
         verifyDownloads ? digestUtil.newHashingOutputStream(out) : null;
     return Futures.transformAsync(
-        get(digest, hashOut != null ? hashOut : out, /* casDownload= */ true),
+        retrier.executeAsync(
+            () -> get(digest, hashOut != null ? hashOut : out, /* casDownload= */ true)),
         (v) -> {
           try {
             if (hashOut != null) {
@@ -645,11 +705,13 @@ public final class HttpCacheClient implements RemoteCacheClient {
   @Override
   public ListenableFuture<ActionResult> downloadActionResult(ActionKey actionKey) {
     return Utils.downloadAsActionResult(
-        actionKey, (digest, out) -> get(digest, out, /* casDownload= */ false));
+        actionKey, (digest, out) ->
+            retrier.executeAsync(
+                () -> get(digest, out, /* casDownload= */ false)));
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
-  private void uploadBlocking(String key, long length, InputStream in, boolean casUpload)
+  private Void uploadBlocking(String key, long length, InputStream in, boolean casUpload)
       throws IOException, InterruptedException {
     InputStream wrappedIn =
         new FilterInputStream(in) {
@@ -684,7 +746,7 @@ public final class HttpCacheClient implements RemoteCacheClient {
             }
             putAfterCredentialRefresh(upload);
             success = true;
-            return;
+            return null;
           }
         }
         throw e;
@@ -698,12 +760,14 @@ public final class HttpCacheClient implements RemoteCacheClient {
         }
       }
     }
+    return null;
   }
 
   @Override
   public ListenableFuture<Void> uploadFile(Digest digest, Path file) {
     try (InputStream in = file.getInputStream()) {
-      uploadBlocking(digest.getHash(), digest.getSizeBytes(), in, /* casUpload= */ true);
+      retrier.execute(
+          () -> uploadBlocking(digest.getHash(), digest.getSizeBytes(), in, /* casUpload= */ true));
     } catch (IOException | InterruptedException e) {
       return Futures.immediateFailedFuture(e);
     }
@@ -713,7 +777,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
   @Override
   public ListenableFuture<Void> uploadBlob(Digest digest, ByteString data) {
     try (InputStream in = data.newInput()) {
-      uploadBlocking(digest.getHash(), digest.getSizeBytes(), in, /* casUpload= */ true);
+      retrier.execute(
+          () -> uploadBlocking(digest.getHash(), digest.getSizeBytes(), in, /* casUpload= */ true));
     } catch (IOException | InterruptedException e) {
       return Futures.immediateFailedFuture(e);
     }
@@ -764,7 +829,9 @@ public final class HttpCacheClient implements RemoteCacheClient {
   public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(Iterable<Digest> digests) {
     ImmutableList.Builder<ListenableFuture<Digest>> queries = ImmutableList.builder();
     for (Digest digest : digests) {
-      queries.add(findMissingDigest(digest, SettableFuture.create(), true));
+      queries.add(
+          retrier.executeAsync(
+              ()-> findMissingDigest(digest, SettableFuture.create(), true)));
     }
 
     return Futures.transformAsync(
@@ -814,7 +881,8 @@ public final class HttpCacheClient implements RemoteCacheClient {
       throws IOException, InterruptedException {
     ByteString serialized = actionResult.toByteString();
     try (InputStream in = serialized.newInput()) {
-      uploadBlocking(actionKey.getDigest().getHash(), serialized.size(), in, false);
+      retrier.execute(
+          () -> uploadBlocking(actionKey.getDigest().getHash(), serialized.size(), in, false));
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.remote.RemoteRetrier;
 import com.google.devtools.build.lib.remote.Retrier;
+import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -59,7 +60,6 @@ import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
@@ -309,18 +309,26 @@ public final class HttpCacheClient implements RemoteCacheClient {
   }
 
   public static RemoteRetrier newRetrier(RemoteOptions options) {
+    CircuitBreaker circuitBreaker =
+        options != null && options.remoteMaxFailureRate > 0
+            ? new Retrier.FailureRateCircuitBreaker(options.remoteMaxFailureRate)
+            : Retrier.ALLOW_ALL_CALLS;
+    return newRetrier(options, circuitBreaker);
+  }
+
+  public static RemoteRetrier newRetrier(RemoteOptions options, CircuitBreaker circuitBreaker) {
     if (options == null || options.remoteMaxRetryAttempts <= 0) {
       return new RemoteRetrier(
           () -> Retrier.RETRIES_DISABLED,
           (Exception e) -> false,
           MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1)),
-          Retrier.ALLOW_ALL_CALLS);
+          circuitBreaker);
     }
     return new RemoteRetrier(
         () -> new RemoteRetrier.ExponentialBackoff(options),
         (Exception e) -> shouldRetry(e),
         MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1)),
-        Retrier.ALLOW_ALL_CALLS);
+        circuitBreaker);
   }
 
   private static boolean shouldRetry(Exception e) {

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -235,6 +235,17 @@ public final class RemoteOptions extends OptionsBase {
   public int remoteMaxRetryAttempts;
 
   @Option(
+      name = "remote_max_failure_rate",
+      defaultValue = "0",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "The maximum tolerable failure rate above which no more communications"
+              + " with the remote server are attempted. If set to 0, the option is disabled."
+              + " This only works with HTTP cache at the moment.")
+  public double remoteMaxFailureRate;
+
+  @Option(
       name = "disk_cache",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,

--- a/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -20,9 +20,12 @@ java_test(
     ],
     test_class = "com.google.devtools.build.lib.AllTests",
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/remote:Retrier",
         "//src/main/java/com/google/devtools/build/lib/remote/http",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/common/options:options_internal",
         "//src/test/java/com/google/devtools/build/lib:test_runner",
         "//src/test/java/com/google/devtools/build/lib:testutil",
         "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http",

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -271,7 +271,8 @@ public class HttpCacheClientTest {
           remoteVerifyDownloads,
           ImmutableList.of(),
           DIGEST_UTIL,
-          creds);
+          creds,
+          null);
     } else if (socketAddress instanceof InetSocketAddress) {
       InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
       URI uri = new URI("http://localhost:" + inetSocketAddress.getPort());
@@ -282,7 +283,8 @@ public class HttpCacheClientTest {
           remoteVerifyDownloads,
           ImmutableList.of(),
           DIGEST_UTIL,
-          creds);
+          creds,
+          null);
     } else {
       throw new IllegalStateException(
           "unsupported socket address class " + socketAddress.getClass());

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -33,10 +33,16 @@ import com.google.auth.Credentials;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.remote.RemoteRetrier;
+import com.google.devtools.build.lib.remote.Retrier.FailureRateCircuitBreaker;
+import com.google.devtools.build.lib.remote.Retrier.CircuitBreakerException;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.testutil.MoreAsserts.ThrowingRunnable;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.remote.worker.http.HttpCacheServerHandler;
+import com.google.devtools.common.options.Options;
 import com.google.protobuf.ByteString;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
@@ -89,6 +95,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntFunction;
 import javax.annotation.Nullable;
@@ -257,7 +264,8 @@ public class HttpCacheClientTest {
       ServerChannel serverChannel,
       int timeoutSeconds,
       boolean remoteVerifyDownloads,
-      @Nullable final Credentials creds)
+      @Nullable final Credentials creds,
+      @Nullable RemoteRetrier retrier)
       throws Exception {
     SocketAddress socketAddress = serverChannel.localAddress();
     if (socketAddress instanceof DomainSocketAddress) {
@@ -272,7 +280,7 @@ public class HttpCacheClientTest {
           ImmutableList.of(),
           DIGEST_UTIL,
           creds,
-          null);
+          retrier);
     } else if (socketAddress instanceof InetSocketAddress) {
       InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
       URI uri = new URI("http://localhost:" + inetSocketAddress.getPort());
@@ -284,11 +292,19 @@ public class HttpCacheClientTest {
           ImmutableList.of(),
           DIGEST_UTIL,
           creds,
-          null);
+          retrier);
     } else {
       throw new IllegalStateException(
           "unsupported socket address class " + socketAddress.getClass());
     }
+  }
+
+  private HttpCacheClient createHttpBlobStore(
+      ServerChannel serverChannel,
+      int timeoutSeconds,
+      boolean remoteVerifyDownloads,
+      @Nullable final Credentials creds) throws Exception {
+    return createHttpBlobStore(serverChannel, timeoutSeconds, remoteVerifyDownloads, creds, null);
   }
 
   private HttpCacheClient createHttpBlobStore(
@@ -372,6 +388,163 @@ public class HttpCacheClientTest {
       assertThat(blobStore.findMissingDigests(ImmutableSet.of(zero, a, b)).get())
           .isEqualTo(ImmutableSet.of());
       assertThat(headCounter.get()).isEqualTo(3);
+    } finally {
+      testServer.stop(server);
+    }
+  }
+
+  @Test
+  public void testRetriesDisabled() throws Exception {
+    ServerChannel server = null;
+    try {
+      AtomicInteger hitCounter = new AtomicInteger(0);
+      server =
+          testServer.start(
+              new SimpleChannelInboundHandler<FullHttpRequest>() {
+
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
+                  hitCounter.incrementAndGet();
+
+                  FullHttpResponse response =
+                      new DefaultFullHttpResponse(
+                          HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+                  HttpUtil.setContentLength(response, 0);
+                  ctx.writeAndFlush(response);
+                }
+              });
+
+      HttpCacheClient blobStore =
+          createHttpBlobStore(server, /* timeoutSeconds= */ 1, /* credentials= */ null);
+
+      ByteString data = ByteString.copyFrom("foo bar", StandardCharsets.UTF_8);
+      Digest digest = DIGEST_UTIL.compute(data.toByteArray());
+
+      for (int i = 1; i < 3; i++) {
+        ListenableFuture<Void> future = blobStore.downloadBlob(digest, new ByteArrayOutputStream());
+
+        ExecutionException e = assertThrows(ExecutionException.class, () -> future.get());
+        assertThat(e.getCause()).isInstanceOf(HttpException.class);
+
+        assertThat(hitCounter.get()).isEqualTo(i);
+      }
+    } finally {
+      testServer.stop(server);
+    }
+  }
+
+  @Test
+  public void testRetries() throws Exception {
+    ServerChannel server = null;
+    try {
+      Map<String, Integer> hitCounters = new ConcurrentHashMap<>();
+      server =
+          testServer.start(
+              new SimpleChannelInboundHandler<FullHttpRequest>() {
+
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
+                  Integer current = hitCounters.getOrDefault(request.uri(), 0);
+                  hitCounters.put(request.uri(), current + 1);
+                  FullHttpResponse response;
+
+                  // Return 500 every time the digest is requested for the first time
+                  // to force a retry. Return 200 in any other case
+                  if (current > 0) {
+                    response =
+                        new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+                  } else {
+                    response =
+                        new DefaultFullHttpResponse(
+                            HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+                  }
+                  HttpUtil.setContentLength(response, 0);
+                  ctx.writeAndFlush(response);
+                }
+              });
+
+      HttpCacheClient blobStore =
+          createHttpBlobStore(
+              server,
+              /* timeoutSeconds= */ 1,
+              /* verify download */ false,
+              /* credentials= */ null,
+              HttpCacheClient.newRetrier(Options.getDefaults(RemoteOptions.class)));
+
+      ByteString a = ByteString.copyFrom("a", StandardCharsets.UTF_8);
+      Digest aDigest = DIGEST_UTIL.compute(a.toByteArray());
+      ByteString b = ByteString.copyFrom("b", StandardCharsets.UTF_8);
+      Digest bDigest = DIGEST_UTIL.compute(b.toByteArray());
+      ByteString c = ByteString.copyFrom("c", StandardCharsets.UTF_8);
+      Digest cDigest = DIGEST_UTIL.compute(c.toByteArray());
+
+      blobStore.downloadBlob(aDigest, new ByteArrayOutputStream()).get();
+      blobStore.downloadBlob(bDigest, new ByteArrayOutputStream()).get();
+      blobStore.downloadBlob(cDigest, new ByteArrayOutputStream()).get();
+      blobStore.downloadBlob(cDigest, new ByteArrayOutputStream()).get();
+
+      assertThat(hitCounters.get("/" + HttpCacheClient.CAS_PREFIX + aDigest.getHash()))
+          .isEqualTo(2);
+      assertThat(hitCounters.get("/" + HttpCacheClient.CAS_PREFIX + bDigest.getHash()))
+          .isEqualTo(2);
+      assertThat(hitCounters.get("/" + HttpCacheClient.CAS_PREFIX + cDigest.getHash()))
+          .isEqualTo(3);
+    } finally {
+      testServer.stop(server);
+    }
+  }
+
+  @Test
+  public void testMaxFailureRate() throws Exception {
+    ServerChannel server = null;
+    try {
+      AtomicInteger hitCounter = new AtomicInteger(0);
+      server =
+          testServer.start(
+              new SimpleChannelInboundHandler<FullHttpRequest>() {
+
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
+                  hitCounter.incrementAndGet();
+                  FullHttpResponse response =
+                      new DefaultFullHttpResponse(
+                          HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+                  HttpUtil.setContentLength(response, 0);
+                  ctx.writeAndFlush(response);
+                }
+              });
+
+      RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+      options.remoteMaxFailureRate = 0.2;
+      options.remoteMaxRetryAttempts = 3;
+      FailureRateCircuitBreaker circuitBreaker= new FailureRateCircuitBreaker(
+          /* maxFailureRate */ options.remoteMaxFailureRate,
+          /* minExecutionsToComputeFailureRate */ 5
+      );
+      HttpCacheClient blobStore =
+          createHttpBlobStore(
+              server,
+              /* timeoutSeconds= */ 1,
+              /* verify download */ false,
+              /* credentials= */ null,
+              HttpCacheClient.newRetrier(options, circuitBreaker));
+
+      ByteString data = ByteString.copyFrom("foo", StandardCharsets.UTF_8);
+      Digest digest = DIGEST_UTIL.compute(data.toByteArray());
+
+      ExecutionException e = assertThrows(
+          ExecutionException.class,
+          () -> blobStore.downloadBlob(digest, new ByteArrayOutputStream()).get()
+      );
+      assertThat(e.getCause()).isInstanceOf(HttpException.class);
+
+      e = assertThrows(
+          ExecutionException.class,
+          () -> blobStore.downloadBlob(digest, new ByteArrayOutputStream()).get()
+      );
+      assertThat(e.getCause()).isInstanceOf(CircuitBreakerException.class);
+
+      assertThat(hitCounter.get()).isEqualTo(5);
     } finally {
       testServer.stop(server);
     }


### PR DESCRIPTION
Add retrier logic in HTTP cache to retry transient errors. Also, add `--remote_max_failures` to stop communications with unhealthy remote servers.