### PR TITLE
[Uber/ios/5.4.0.001] Address output / config hash differences when building bundles vs. building libraries

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
@@ -385,6 +385,19 @@ public final class FunctionTransitionUtil {
               .merge(toOptions == null ? fromOptions.clone() : toOptions)
               .addStarlarkOptions(changedStarlarkOptions)
               .build();
+    } else {
+      // Uber Hack: Force exposing apple split cpu into transition hash key if there's a valid transition
+      // Transition hash only record the changed fregment set, for some reason a multi_arch_split transition seems to:
+      // - result in changed apple_split_cpu from default "" to host cpu
+      // - applied before the starlark transition difference analysis here
+      // we also remove ios_cpu from the transition evaluation as it's in the process of deprecation and poorly handled.
+      // Ideally we should fix the root cause, this is more or less a lazy hack
+      if (newValues.keySet().contains("//command_line_option:apple_split_cpu")) {
+        convertedNewValues.add("//command_line_option:apple_split_cpu");
+      }
+      if (newValues.keySet().contains("//command_line_option:ios_cpu")) {
+        convertedNewValues.remove("//command_line_option:ios_cpu");
+      }
     }
     if (toOptions == null) {
       return fromOptions;


### PR DESCRIPTION
Output directories is very different when the top level target is bundle vs. libraries.

There're actually two issues causing this:
- a native app cpu split transition is getting applied in rules_apple's binary rule: https://github.com/bazelbuild/rules_apple/blob/5b8217613aa1ef4d889477d036590979858dbf4e/apple/internal/rule_factory.bzl#L300, while it's technically correct, the timing of the transition change seems to be happening earlier than the transition difference calculation, as bazel only apply "changed transition scope" to its ST- hash, this native transition seems to be applied unaccounted for during transition hash calculation.
- output directory differences, even with the config hash aligned, all ios rule output derived from bundle deps will go with the bundle output mnemonic, this again is caused by the split cpu being applied later than the output directory config is set. 

After addressing the above, there's a separate issue where ios_cpu is always read to be its default vaule for the top level target, regardless of the transition.

The current state of apple_cplit_cpu and ios_cpu is pretty hacky already, A good solution to reconcile all these selectively forcing or ignoring those keys during transition hash calculation, while fixing the ios_cpu value in https://code.uberinternal.com/D9215037

these commits are more or less hacks and can be potentially dangerous, but i don't see us out of this native/starlark limbo for a while now, we should re-evaluate these if one day all cpp rules are out of bazel core