### PR TITLE
[Android] Remove desugar_jdk_libs.jar from android_tools tar

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
@@ -355,8 +355,6 @@ public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
         throw new RuntimeException("Failure to compute hash for " + fileObject, ex);
       }
     }
-      }
-    }
 
     /**
      * Marks the provided dependency as a direct/explicit dependency. Additionally, if

--- a/tools/android/runtime_deps/BUILD.bazel
+++ b/tools/android/runtime_deps/BUILD.bazel
@@ -82,7 +82,6 @@ pkg_tar(
     srcs = [
         "BUILD",
         "WORKSPACE",
-        ":desugar_jdk_libs.jar",
         ":version.txt",
         "//src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps:ImportDepsChecker_deploy.jar",
     ],


### PR DESCRIPTION
## Summary

Remove `desugar_jdk_libs.jar` from the `android_tools` `pkg_tar` target. The file no longer exists in the Bazel 8 tree, causing the android_tools bootstrap build to fail.

Depends on #32

## Test plan
- Built Bazel binary, java_tools, and android_tools successfully from this branch

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>