### PR TITLE
[Android] Fix stray closing braces in StrictJavaDepsPlugin

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/dependency/StrictJavaDepsPlugin.java
@@ -355,8 +355,6 @@ public final class StrictJavaDepsPlugin extends BlazeJavaCompilerPlugin {
         throw new RuntimeException("Failure to compute hash for " + fileObject, ex);
       }
     }
-      }
-    }
 
     /**
      * Marks the provided dependency as a direct/explicit dependency. Additionally, if


### PR DESCRIPTION
## Summary

Remove two extra closing braces in `StrictJavaDepsPlugin.java` that cause a syntax error (`unexpected token: void`) during the java_tools bootstrap build.

## Test plan
- Built Bazel binary and java_tools successfully from this branch

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>