### PR TITLE
[Android] Add --mnemonic_cache_salt flag for Bazel 8.1.1

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
@@ -559,7 +559,8 @@ public class ActionCacheChecker {
       OutputMetadataStore outputMetadataStore,
       ArtifactExpander artifactExpander,
       Map<String, String> remoteDefaultPlatformProperties,
-      @Nullable RemoteArtifactChecker remoteArtifactChecker)
+      @Nullable RemoteArtifactChecker remoteArtifactChecker,
+      ImmutableMap<String, String> mnemonicCacheSalts)
       throws InterruptedException {
     // TODO(bazel-team): (2010) For RunfilesAction/SymlinkAction and similar actions that
     // produce only symlinks we should not check whether inputs are valid at all - all that matters
@@ -618,7 +619,8 @@ public class ActionCacheChecker {
         outputPermissions,
         remoteDefaultPlatformProperties,
         cachedOutputMetadata,
-        remoteArtifactChecker)) {
+        remoteArtifactChecker,
+        mnemonicCacheSalts.get(action.getMnemonic()))) {
       if (entry != null) {
         removeCacheEntry(action);
       }
@@ -638,6 +640,34 @@ public class ActionCacheChecker {
     return null;
   }
 
+  /** Backward-compat overload for callers that don't pass mnemonicCacheSalts. */
+  @Nullable
+  public Token getTokenIfNeedToExecute(
+      Action action,
+      List<Artifact> resolvedCacheArtifacts,
+      Map<String, String> clientEnv,
+      OutputPermissions outputPermissions,
+      EventHandler handler,
+      InputMetadataProvider inputMetadataProvider,
+      OutputMetadataStore outputMetadataStore,
+      ArtifactExpander artifactExpander,
+      Map<String, String> remoteDefaultPlatformProperties,
+      @Nullable RemoteArtifactChecker remoteArtifactChecker)
+      throws InterruptedException {
+    return getTokenIfNeedToExecute(
+        action,
+        resolvedCacheArtifacts,
+        clientEnv,
+        outputPermissions,
+        handler,
+        inputMetadataProvider,
+        outputMetadataStore,
+        artifactExpander,
+        remoteDefaultPlatformProperties,
+        remoteArtifactChecker,
+        ImmutableMap.of());
+  }
+
   private boolean mustExecute(
       Action action,
       @Nullable ActionCache.Entry entry,
@@ -651,7 +681,8 @@ public class ActionCacheChecker {
       OutputPermissions outputPermissions,
       Map<String, String> remoteDefaultPlatformProperties,
       @Nullable CachedOutputMetadata cachedOutputMetadata,
-      @Nullable RemoteArtifactChecker remoteArtifactChecker)
+      @Nullable RemoteArtifactChecker remoteArtifactChecker,
+      @Nullable String mnemonicSalt)
       throws InterruptedException {
     // Unconditional execution can be applied only for actions that are allowed to be executed.
     if (unconditionalExecution(action)) {
@@ -696,7 +727,7 @@ public class ActionCacheChecker {
 
     Map<String, String> usedEnvironment =
         computeUsedEnv(action, clientEnv, remoteDefaultPlatformProperties);
-    if (!entry.sameActionProperties(usedEnvironment, outputPermissions)) {
+    if (!entry.sameActionProperties(usedEnvironment, outputPermissions, mnemonicSalt)) {
       reportClientEnv(handler, action, usedEnvironment);
       actionCache.accountMiss(MissReason.DIFFERENT_ENVIRONMENT);
       return true;
@@ -771,7 +802,8 @@ public class ActionCacheChecker {
       Map<String, String> clientEnv,
       OutputPermissions outputPermissions,
       Map<String, String> remoteDefaultPlatformProperties,
-      boolean isDelayedUpdate)
+      boolean isDelayedUpdate,
+      ImmutableMap<String, String> mnemonicCacheSalts)
       throws IOException, InterruptedException {
     checkState(cacheConfig.enabled(), "cache unexpectedly disabled, action: %s", action);
     Preconditions.checkArgument(token != null, "token unexpectedly null, action: %s", action);
@@ -797,7 +829,8 @@ public class ActionCacheChecker {
 
     ActionCache.Entry entry =
         new ActionCache.Entry(
-            actionKey, usedEnvironment, action.discoversInputs(), outputPermissions);
+            actionKey, usedEnvironment, action.discoversInputs(), outputPermissions,
+            mnemonicCacheSalts.get(action.getMnemonic()));
     for (Artifact output : action.getOutputs()) {
       // Remove old records from the cache if they used different key.
       String execPath = output.getExecPathString();
@@ -864,7 +897,8 @@ public class ActionCacheChecker {
                 clientEnv,
                 outputPermissions,
                 remoteDefaultPlatformProperties,
-                true /* isDelayedUpdate */
+                true /* isDelayedUpdate */,
+                mnemonicCacheSalts
         );
       }
     }
@@ -879,6 +913,55 @@ public class ActionCacheChecker {
         }
       }
     }
+  }
+
+  /** Backward-compat overload for callers that don't pass mnemonicCacheSalts. */
+  public void updateActionCache(
+      Action action,
+      Token token,
+      InputMetadataProvider inputMetadataProvider,
+      OutputMetadataStore outputMetadataStore,
+      ArtifactExpander artifactExpander,
+      Map<String, String> clientEnv,
+      OutputPermissions outputPermissions,
+      Map<String, String> remoteDefaultPlatformProperties,
+      boolean isDelayedUpdate)
+      throws IOException, InterruptedException {
+    updateActionCache(
+        action,
+        token,
+        inputMetadataProvider,
+        outputMetadataStore,
+        artifactExpander,
+        clientEnv,
+        outputPermissions,
+        remoteDefaultPlatformProperties,
+        isDelayedUpdate,
+        ImmutableMap.of());
+  }
+
+  /** Backward-compat overload for callers that don't pass isDelayedUpdate or mnemonicCacheSalts. */
+  public void updateActionCache(
+      Action action,
+      Token token,
+      InputMetadataProvider inputMetadataProvider,
+      OutputMetadataStore outputMetadataStore,
+      ArtifactExpander artifactExpander,
+      Map<String, String> clientEnv,
+      OutputPermissions outputPermissions,
+      Map<String, String> remoteDefaultPlatformProperties)
+      throws IOException, InterruptedException {
+    updateActionCache(
+        action,
+        token,
+        inputMetadataProvider,
+        outputMetadataStore,
+        artifactExpander,
+        clientEnv,
+        outputPermissions,
+        remoteDefaultPlatformProperties,
+        /* isDelayedUpdate= */ false,
+        ImmutableMap.of());
   }
 
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
@@ -176,8 +176,17 @@ public interface ActionCache {
         Map<String, String> usedClientEnv,
         boolean discoversInputs,
         OutputPermissions outputPermissions) {
+      this(key, usedClientEnv, discoversInputs, outputPermissions, null);
+    }
+
+    public Entry(
+        String key,
+        Map<String, String> usedClientEnv,
+        boolean discoversInputs,
+        OutputPermissions outputPermissions,
+        @Nullable String mnemonicSalt) {
       actionKey = key;
-      this.actionPropertiesDigest = digestActionProperties(usedClientEnv, outputPermissions);
+      this.actionPropertiesDigest = digestActionProperties(usedClientEnv, outputPermissions, mnemonicSalt);
       files = discoversInputs ? new ArrayList<>() : null;
       mdMap = new HashMap<>();
       outputFileMetadata = new HashMap<>();
@@ -206,6 +215,11 @@ public interface ActionCache {
      */
     private static byte[] digestActionProperties(
         Map<String, String> clientEnv, OutputPermissions outputPermissions) {
+      return digestActionProperties(clientEnv, outputPermissions, null);
+    }
+
+    private static byte[] digestActionProperties(
+        Map<String, String> clientEnv, OutputPermissions outputPermissions, @Nullable String mnemonicSalt) {
       byte[] result = EMPTY_CLIENT_ENV_DIGEST;
       Fingerprint fp = new Fingerprint();
       for (Map.Entry<String, String> entry : clientEnv.entrySet()) {
@@ -219,6 +233,10 @@ public interface ActionCache {
       if (outputPermissions != OutputPermissions.READONLY) {
         fp.addInt(outputPermissions.getPermissionsMode());
         result = DigestUtils.combineUnordered(result, fp.digestAndReset());
+      }
+      if (mnemonicSalt != null) {
+        fp.addString(mnemonicSalt);
+        result = DigestUtils.xor(result, fp.digestAndReset());
       }
       return result;
     }
@@ -323,9 +341,9 @@ public interface ActionCache {
 
     /** Determines whether this entry has the same action properties as the one given. */
     public boolean sameActionProperties(
-        Map<String, String> clientEnv, OutputPermissions outputPermissions) {
+        Map<String, String> clientEnv, OutputPermissions outputPermissions, @Nullable String mnemonicSalt) {
       return Arrays.equals(
-          digestActionProperties(clientEnv, outputPermissions), actionPropertiesDigest);
+          digestActionProperties(clientEnv, outputPermissions, mnemonicSalt), actionPropertiesDigest);
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -340,8 +340,11 @@ public class ExecutionTool {
         remoteArtifactChecker,
         buildRequestOptions.fsvcThreads);
     try (SilentCloseable c = Profiler.instance().profile("configureActionExecutor")) {
+      ExecutionOptions executionOptions = request.getOptions(ExecutionOptions.class);
       skyframeExecutor.configureActionExecutor(
-          skyframeBuilder.getFileCache(), skyframeBuilder.getActionInputPrefetcher());
+          skyframeBuilder.getFileCache(),
+          skyframeBuilder.getActionInputPrefetcher(),
+          executionOptions != null ? executionOptions.getMnemonicCacheSalts() : ImmutableMap.of());
     }
 
     skyframeExecutor.deleteActionsIfRemoteOptionsChanged(request);
@@ -953,6 +956,9 @@ public class ExecutionTool {
       ModifiedFileSet modifiedOutputFiles,
       boolean shouldStoreRemoteOutputMetadataInActionCache) {
     BuildRequestOptions options = request.getBuildOptions();
+    ExecutionOptions executionOptions = request.getOptions(ExecutionOptions.class);
+    ImmutableMap<String, String> mnemonicCacheSalts =
+        executionOptions != null ? executionOptions.getMnemonicCacheSalts() : ImmutableMap.of();
 
     skyframeExecutor.setActionOutputRoot(env.getActionTempsDirectory());
 
@@ -986,7 +992,8 @@ public class ExecutionTool {
         env.getFileCache(),
         prefetcher,
         env.getOutputDirectoryHelper(),
-        env.getRuntime().getBugReporter());
+        env.getRuntime().getBugReporter(),
+        mnemonicCacheSalts);
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/buildtool/SkyframeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/SkyframeBuilder.java
@@ -18,6 +18,7 @@ import static com.google.devtools.build.lib.skyframe.CoverageReportValue.COVERAG
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
@@ -72,6 +73,7 @@ public class SkyframeBuilder implements Builder {
   private final ActionOutputDirectoryHelper actionOutputDirectoryHelper;
   private final ActionCacheChecker actionCacheChecker;
   private final BugReporter bugReporter;
+  private final ImmutableMap<String, String> mnemonicCacheSalts;
 
   @VisibleForTesting
   public SkyframeBuilder(
@@ -83,6 +85,28 @@ public class SkyframeBuilder implements Builder {
       ActionInputPrefetcher actionInputPrefetcher,
       ActionOutputDirectoryHelper actionOutputDirectoryHelper,
       BugReporter bugReporter) {
+    this(
+        skyframeExecutor,
+        resourceManager,
+        actionCacheChecker,
+        modifiedOutputFiles,
+        fileCache,
+        actionInputPrefetcher,
+        actionOutputDirectoryHelper,
+        bugReporter,
+        ImmutableMap.of());
+  }
+
+  public SkyframeBuilder(
+      SkyframeExecutor skyframeExecutor,
+      ResourceManager resourceManager,
+      ActionCacheChecker actionCacheChecker,
+      ModifiedFileSet modifiedOutputFiles,
+      InputMetadataProvider fileCache,
+      ActionInputPrefetcher actionInputPrefetcher,
+      ActionOutputDirectoryHelper actionOutputDirectoryHelper,
+      BugReporter bugReporter,
+      ImmutableMap<String, String> mnemonicCacheSalts) {
     this.resourceManager = resourceManager;
     this.skyframeExecutor = skyframeExecutor;
     this.actionCacheChecker = actionCacheChecker;
@@ -91,6 +115,7 @@ public class SkyframeBuilder implements Builder {
     this.actionInputPrefetcher = actionInputPrefetcher;
     this.actionOutputDirectoryHelper = actionOutputDirectoryHelper;
     this.bugReporter = bugReporter;
+    this.mnemonicCacheSalts = mnemonicCacheSalts;
   }
 
   @Override
@@ -115,7 +140,7 @@ public class SkyframeBuilder implements Builder {
     skyframeExecutor.detectModifiedOutputFiles(
         modifiedOutputFiles, lastExecutionTimeRange, remoteArtifactChecker, fsvcThreads);
     try (SilentCloseable c = Profiler.instance().profile("configureActionExecutor")) {
-      skyframeExecutor.configureActionExecutor(fileCache, actionInputPrefetcher);
+      skyframeExecutor.configureActionExecutor(fileCache, actionInputPrefetcher, mnemonicCacheSalts);
     }
     // Note that executionProgressReceiver accesses builtTargets concurrently (after wrapping in a
     // synchronized collection), so unsynchronized access to this variable is unsafe while it runs.

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.exec;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionContext.ShowSubcommands;
@@ -561,6 +562,36 @@ public class ExecutionOptions extends OptionsBase {
               + " --incompatible_remote_use_new_exit_code_for_lost_inputs and check for the exit"
               + " code 39.")
   public int remoteRetryOnTransientCacheError;
+
+  @Option(
+      name = "mnemonic_cache_salt",
+      allowMultiple = true,
+      converter = Converters.AssignmentConverter.class,
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.EXECUTION, OptionEffectTag.ACTION_COMMAND_LINES},
+      help =
+          "Specify a salt value to include in the cache key for actions with a given mnemonic. "
+              + "Format: --mnemonic_cache_salt=Mnemonic=salt. "
+              + "This invalidates both local and remote cache entries for that mnemonic. "
+              + "Example: --mnemonic_cache_salt=Javac=V2 --mnemonic_cache_salt=KotlinCompile=V3")
+  public List<Map.Entry<String, String>> mnemonicCacheSalts;
+
+  /**
+   * Returns the mnemonic cache salts as an immutable map.
+   *
+   * <p>If the same mnemonic is specified multiple times, the last value wins.
+   */
+  public ImmutableMap<String, String> getMnemonicCacheSalts() {
+    if (mnemonicCacheSalts == null || mnemonicCacheSalts.isEmpty()) {
+      return ImmutableMap.of();
+    }
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    for (Map.Entry<String, String> entry : mnemonicCacheSalts) {
+      builder.put(entry.getKey(), entry.getValue());
+    }
+    return builder.buildKeepingLast();
+  }
 
   /** An enum for specifying different formats of test output. */
   public enum TestOutputFormat {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -191,6 +191,12 @@ final class RemoteActionContextProvider {
               outputService,
               knownMissingCasDigests);
       env.getEventBus().register(remoteExecutionService);
+      ExecutionOptions remoteExecExecutionOptions =
+          env.getOptions().getOptions(ExecutionOptions.class);
+      if (remoteExecExecutionOptions != null) {
+        remoteExecutionService.setMnemonicCacheSalts(
+            remoteExecExecutionOptions.getMnemonicCacheSalts());
+      }
     }
 
     return remoteExecutionService;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -201,6 +201,7 @@ public class RemoteExecutionService {
   private final Set<Digest> knownMissingCasDigests;
 
   private Boolean useOutputPaths;
+  private ImmutableMap<String, String> mnemonicCacheSalts = ImmutableMap.of();
 
   public RemoteExecutionService(
       Executor executor,
@@ -343,6 +344,11 @@ public class RemoteExecutionService {
     boolean allowDiskCache = useDiskCache() && Spawns.mayBeCached(spawn);
 
     return CachePolicy.create(allowRemoteCache, allowDiskCache);
+  }
+
+  /** Sets the per-mnemonic cache salts for targeted cache invalidation. */
+  public void setMnemonicCacheSalts(ImmutableMap<String, String> mnemonicCacheSalts) {
+    this.mnemonicCacheSalts = mnemonicCacheSalts;
   }
 
   /** Returns {@code true} if the spawn may be executed remotely. */
@@ -506,7 +512,7 @@ public class RemoteExecutionService {
   }
 
   @Nullable
-  private static ByteString buildSalt(Spawn spawn, @Nullable SpawnScrubber spawnScrubber) {
+  private static ByteString buildSalt(Spawn spawn, @Nullable SpawnScrubber spawnScrubber, ImmutableMap<String, String> mnemonicCacheSalts) {
     CacheSalt.Builder saltBuilder =
         CacheSalt.newBuilder().setMayBeExecutedRemotely(Spawns.mayBeExecutedRemotely(spawn));
 
@@ -519,6 +525,12 @@ public class RemoteExecutionService {
     if (spawnScrubber != null) {
       saltBuilder.setScrubSalt(
           CacheSalt.ScrubSalt.newBuilder().setSalt(spawnScrubber.getSalt()).build());
+    }
+
+    // Add mnemonic-specific salt for targeted cache invalidation.
+    String mnemonicSalt = mnemonicCacheSalts.get(spawn.getMnemonic());
+    if (mnemonicSalt != null) {
+      saltBuilder.setMnemonicSalt(mnemonicSalt);
     }
 
     return saltBuilder.build().toByteString();
@@ -672,7 +684,7 @@ public class RemoteExecutionService {
               platform,
               context.getTimeout(),
               Spawns.mayBeCachedRemotely(spawn),
-              buildSalt(spawn, spawnScrubber));
+              buildSalt(spawn, spawnScrubber, mnemonicCacheSalts));
 
       ActionKey actionKey = digestUtil.computeActionKey(action);
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -205,6 +205,7 @@ public final class SkyframeActionExecutor {
   private boolean freeDiscoveredInputsAfterExecution;
   private InputMetadataProvider perBuildFileCache;
   private ActionInputPrefetcher actionInputPrefetcher;
+  private ImmutableMap<String, String> mnemonicCacheSalts = ImmutableMap.of();
   /** These variables are nulled out between executions. */
   @Nullable private ProgressSupplier progressSupplier;
 
@@ -684,7 +685,8 @@ public final class SkyframeActionExecutor {
               outputMetadataStore,
               artifactExpander,
               remoteDefaultProperties,
-              remoteArtifactChecker);
+              remoteArtifactChecker,
+              mnemonicCacheSalts);
 
       if (token == null) {
         boolean eventPosted = false;
@@ -793,7 +795,8 @@ public final class SkyframeActionExecutor {
           clientEnv,
           getOutputPermissions(),
           remoteDefaultProperties,
-          false /* isDelayedUpdate */);
+          false /* isDelayedUpdate */,
+          mnemonicCacheSalts);
     } catch (IOException e) {
       // Skyframe has already done all the filesystem access needed for outputs and swallows
       // IOExceptions for inputs. So an IOException is impossible here.
@@ -954,10 +957,19 @@ public final class SkyframeActionExecutor {
   public void configure(
       InputMetadataProvider fileCache,
       ActionInputPrefetcher actionInputPrefetcher,
-      DiscoveredModulesPruner discoveredModulesPruner) {
+      DiscoveredModulesPruner discoveredModulesPruner,
+      ImmutableMap<String, String> mnemonicCacheSalts) {
     this.perBuildFileCache = fileCache;
     this.actionInputPrefetcher = actionInputPrefetcher;
     this.discoveredModulesPruner = discoveredModulesPruner;
+    this.mnemonicCacheSalts = mnemonicCacheSalts;
+  }
+
+  public void configure(
+      InputMetadataProvider fileCache,
+      ActionInputPrefetcher actionInputPrefetcher,
+      DiscoveredModulesPruner discoveredModulesPruner) {
+    configure(fileCache, actionInputPrefetcher, discoveredModulesPruner, ImmutableMap.of());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -898,9 +898,16 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
   }
 
   public void configureActionExecutor(
-      InputMetadataProvider fileCache, ActionInputPrefetcher actionInputPrefetcher) {
+      InputMetadataProvider fileCache,
+      ActionInputPrefetcher actionInputPrefetcher,
+      ImmutableMap<String, String> mnemonicCacheSalts) {
     skyframeActionExecutor.configure(
-        fileCache, actionInputPrefetcher, DiscoveredModulesPruner.DEFAULT);
+        fileCache, actionInputPrefetcher, DiscoveredModulesPruner.DEFAULT, mnemonicCacheSalts);
+  }
+
+  public void configureActionExecutor(
+      InputMetadataProvider fileCache, ActionInputPrefetcher actionInputPrefetcher) {
+    configureActionExecutor(fileCache, actionInputPrefetcher, ImmutableMap.of());
   }
 
   @ForOverride

--- a/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/DigestUtils.java
@@ -205,4 +205,15 @@ public class DigestUtils {
     }
     return combineUnordered(rhs, lhs);
   }
+
+  public static byte[] xor(byte[] lhs, byte[] rhs) {
+    int n = rhs.length;
+    if (lhs.length >= n) {
+      for (int i = 0; i < n; i++) {
+        lhs[i] ^= rhs[i];
+      }
+      return lhs;
+    }
+    return xor(rhs, lhs);
+  }
 }

--- a/src/main/protobuf/cache_salt.proto
+++ b/src/main/protobuf/cache_salt.proto
@@ -40,4 +40,8 @@ message CacheSalt {
   // Ensures that a scrubbed spawn can never collide with a non-scrubbed one.
   // See the documentation for the --experimental_remote_scrub_config flag.
   ScrubSalt scrub_salt = 3;
+
+  // Per-mnemonic cache salt value for targeted cache invalidation.
+  // See the documentation for the --mnemonic_cache_salt flag.
+  string mnemonic_salt = 4;
 }

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -1752,4 +1752,116 @@ public class ActionCacheCheckerTest {
       return super.execute(actionExecutionContext);
     }
   }
+
+  // ---- Helpers and tests for --mnemonic_cache_salt feature ----
+
+  /**
+   * Runs an action through the cache lifecycle with the given mnemonic salt map. Returns true if
+   * the action needed to execute (cache miss), false if it was a cache hit.
+   */
+  private boolean runActionWithMnemonicSalts(
+      Action action, ImmutableMap<String, String> mnemonicCacheSalts) throws Exception {
+    FakeInputMetadataHandler metadataHandler = new FakeInputMetadataHandler();
+    Token token =
+        cacheChecker.getTokenIfNeedToExecute(
+            action,
+            /* resolvedCacheArtifacts= */ null,
+            /* clientEnv= */ ImmutableMap.of(),
+            OutputPermissions.READONLY,
+            /* handler= */ null,
+            metadataHandler,
+            metadataHandler,
+            /* artifactExpander= */ null,
+            /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+            RemoteArtifactChecker.TRUST_ALL,
+            mnemonicCacheSalts);
+
+    if (token != null) {
+      for (Artifact artifact : action.getOutputs()) {
+        Path path = artifact.getPath();
+        filesToDelete.add(path);
+        Path parent = path.getParentDirectory();
+        if (parent != null) {
+          parent.createDirectoryAndParents();
+        }
+      }
+      ActionExecutionContext context = mock(ActionExecutionContext.class);
+      when(context.getOutputMetadataStore()).thenReturn(metadataHandler);
+      action.execute(context);
+      cacheChecker.updateActionCache(
+          action,
+          token,
+          metadataHandler,
+          metadataHandler,
+          /* artifactExpander= */ null,
+          /* clientEnv= */ ImmutableMap.of(),
+          OutputPermissions.READONLY,
+          /* remoteDefaultPlatformProperties= */ ImmutableMap.of(),
+          /* isDelayedUpdate= */ false,
+          mnemonicCacheSalts);
+    }
+    return token != null;
+  }
+
+  @Test
+  public void testMnemonicCacheSalt_firstRunIsAlwaysCacheMiss() throws Exception {
+    Action action = new WriteEmptyOutputAction();
+    boolean executed = runActionWithMnemonicSalts(action, ImmutableMap.of("Null", "V1"));
+    assertThat(executed).isTrue();
+  }
+
+  @Test
+  public void testMnemonicCacheSalt_secondRunWithSameSaltIsCacheHit() throws Exception {
+    Action action = new WriteEmptyOutputAction();
+    ImmutableMap<String, String> salts = ImmutableMap.of("Null", "V1");
+    runActionWithMnemonicSalts(action, salts);
+    boolean executedAgain = runActionWithMnemonicSalts(action, salts);
+    assertThat(executedAgain).isFalse();
+  }
+
+  @Test
+  public void testMnemonicCacheSalt_changingSaltCausesCacheMiss() throws Exception {
+    Action action = new WriteEmptyOutputAction();
+    runActionWithMnemonicSalts(action, ImmutableMap.of("Null", "V1"));
+    boolean executedAfterSaltChange = runActionWithMnemonicSalts(action, ImmutableMap.of("Null", "V2"));
+    assertThat(executedAfterSaltChange).isTrue();
+  }
+
+  @Test
+  public void testMnemonicCacheSalt_removingSaltCausesCacheMiss() throws Exception {
+    Action action = new WriteEmptyOutputAction();
+    runActionWithMnemonicSalts(action, ImmutableMap.of("Null", "V1"));
+    // Remove the salt entirely: different digest → cache miss
+    boolean executedWithoutSalt = runActionWithMnemonicSalts(action, ImmutableMap.of());
+    assertThat(executedWithoutSalt).isTrue();
+  }
+
+  @Test
+  public void testMnemonicCacheSalt_addingSaltCausesCacheMiss() throws Exception {
+    Action action = new WriteEmptyOutputAction();
+    // First run with no salt
+    runActionWithMnemonicSalts(action, ImmutableMap.of());
+    // Adding a salt should bust the cache
+    boolean executedAfterAddSalt = runActionWithMnemonicSalts(action, ImmutableMap.of("Null", "V1"));
+    assertThat(executedAfterAddSalt).isTrue();
+  }
+
+  @Test
+  public void testMnemonicCacheSalt_saltForDifferentMnemonicDoesNotAffectAction() throws Exception {
+    Action action = new WriteEmptyOutputAction(); // mnemonic is "Null"
+    runActionWithMnemonicSalts(action, ImmutableMap.of("Null", "V1"));
+    // A salt for "Javac" should not affect a "Null" mnemonic action
+    boolean executed = runActionWithMnemonicSalts(action, ImmutableMap.of("Null", "V1", "Javac", "X"));
+    assertThat(executed).isFalse();
+  }
+
+  @Test
+  public void testMnemonicCacheSalt_saltOnlyForDifferentMnemonicDoesNotCauseMiss() throws Exception {
+    Action action = new WriteEmptyOutputAction(); // mnemonic is "Null"
+    // Cache with no salt
+    runActionWithMnemonicSalts(action, ImmutableMap.of());
+    // Salt only for "Javac" should not affect "Null" mnemonic action
+    boolean executed = runActionWithMnemonicSalts(action, ImmutableMap.of("Javac", "V1"));
+    assertThat(executed).isFalse();
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/actions/BUILD
@@ -52,6 +52,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:config/core_options",
         "//src/main/java/com/google/devtools/build/lib/analysis/platform",
         "//src/main/java/com/google/devtools/build/lib/bugreport",
+        "//src/main/java/com/google/devtools/build/lib:build-request-options",
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",


### PR DESCRIPTION
## Summary

Cherry-pick of fae19c5392 from `uber/android/7.6.1` to `uber/android/8.1.1` with adaptations for the Bazel 8 codebase:

- **DigestUtils.xor()**: Backported from 7.6.1 — the method was removed in upstream Bazel 8 (replaced by `combineUnordered`) but is needed by the mnemonic cache salt feature.
- **RemoteExecutionService.buildSalt()**: The method is `static` in 8.1.1 (was non-static in 7.6.1), so `mnemonicCacheSalts` is passed as a parameter instead of accessed as an instance field.

## Test plan
- Built Bazel binary, java_tools, and android_tools successfully from this branch
- Built carbonBundleRelease in the Android monorepo using this binary (with the other two fixes applied separately)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>