### PR TITLE
[Android] Fix zlib fdopen macro breaking macOS builds

### DIFF
--- a/third_party/zlib/zutil.h
+++ b/third_party/zlib/zutil.h
@@ -142,10 +142,6 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
 #      include <unix.h> /* for fdopen */
-#    else
-#      ifndef fdopen
-#        define fdopen(fd,mode) NULL /* No fdopen() */
-#      endif
 #    endif
 #  endif
 #endif


### PR DESCRIPTION
## Summary

On modern macOS, `TARGET_OS_MAC` is always 1 (set by system headers), causing `#define fdopen(fd,mode) NULL` to fire in `third_party/zlib/zutil.h`. This macro replaces the `fdopen` token everywhere, which breaks when the macOS SDK's `_stdio.h` declares `FILE *fdopen(int, const char *)` — the compiler sees `FILE *NULL(int, const char *)` and errors out.

The removed `#else` branch was written for classic Mac OS (pre-OS X) using non-Metrowerks compilers that no longer exist. Modern macOS provides `fdopen` via the system and needs no macro.

## Test plan
- Bazel binary builds successfully on macOS after this fix (previously failed with `fdopen` redefinition error)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>