### PR TITLE
Add null check for label in cache key scrubber

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/Scrubber.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Scrubber.java
@@ -137,7 +137,8 @@ public class Scrubber {
     private boolean matches(Spawn spawn) {
       String mnemonic = spawn.getMnemonic();
       ActionOwner actionOwner = spawn.getResourceOwner().getOwner();
-      String label = actionOwner.getLabel().getCanonicalForm();
+      String label =
+          actionOwner.getLabel() != null ? actionOwner.getLabel().getCanonicalForm() : "";
       String kind = actionOwner.getTargetKind();
       boolean isForTool = actionOwner.isBuildConfigurationForTool();
 

--- a/src/test/java/com/google/devtools/build/lib/exec/util/FakeOwner.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/FakeOwner.java
@@ -41,7 +41,7 @@ import net.starlark.java.syntax.Location;
 public class FakeOwner implements ActionExecutionMetadata {
   private final String mnemonic;
   private final String progressMessage;
-  private final String ownerLabel;
+  @Nullable private final String ownerLabel;
   private final String ownerRuleKind;
   @Nullable private final Artifact primaryOutput;
   @Nullable private final PlatformInfo platform;
@@ -59,7 +59,7 @@ public class FakeOwner implements ActionExecutionMetadata {
       boolean isBuiltForToolConfiguration) {
     this.mnemonic = mnemonic;
     this.progressMessage = progressMessage;
-    this.ownerLabel = checkNotNull(ownerLabel);
+    this.ownerLabel = ownerLabel;
     this.ownerRuleKind = checkNotNull(ownerRuleKind);
     this.primaryOutput = primaryOutput;
     this.platform = platform;
@@ -86,8 +86,9 @@ public class FakeOwner implements ActionExecutionMetadata {
 
   @Override
   public ActionOwner getOwner() {
+    Label parsedLabel = ownerLabel != null ? Label.parseCanonicalUnchecked(ownerLabel) : null;
     return ActionOwner.createDummy(
-        Label.parseCanonicalUnchecked(ownerLabel),
+        parsedLabel,
         new Location("dummy-file", 0, 0),
         ownerRuleKind,
         mnemonic,

--- a/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
@@ -43,7 +43,7 @@ import javax.annotation.Nullable;
 public final class SpawnBuilder {
   private String mnemonic = "Mnemonic";
   private String progressMessage = "progress message";
-  private String ownerLabel = "//dummy:label";
+  @Nullable private String ownerLabel = "//dummy:label";
   private String ownerRuleKind = "dummy-target-kind";
   @Nullable private Artifact ownerPrimaryOutput;
   @Nullable private PlatformInfo platform;
@@ -111,6 +111,13 @@ public final class SpawnBuilder {
   @CanIgnoreReturnValue
   public SpawnBuilder withOwnerLabel(String ownerLabel) {
     this.ownerLabel = checkNotNull(ownerLabel);
+    return this;
+  }
+
+  /** Sets the owner to have no label, simulating synthetic actions (e.g. coverage aggregation). */
+  @CanIgnoreReturnValue
+  public SpawnBuilder withNullOwnerLabel() {
+    this.ownerLabel = null;
     return this;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ScrubberTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ScrubberTest.java
@@ -447,6 +447,35 @@ public class ScrubberTest {
     assertThat(spawnScrubber.transformArgument("foospam")).isEqualTo("fooeggs");
   }
 
+  @Test
+  public void nullOwnerLabelDoesNotThrow() {
+    // Synthetic Bazel actions (e.g. CoverageReportKeySingleton) have a null label on their
+    // ActionOwner. The scrubber must not throw NPE and should treat the label as empty.
+    var scrubber =
+        new Scrubber(
+            Config.newBuilder()
+                .addRules(
+                    Config.Rule.newBuilder()
+                        .setMatcher(Config.Matcher.newBuilder().setMnemonic("CoverageReport")))
+                .build());
+
+    assertThat(scrubber.forSpawn(createSpawnWithNullLabel("CoverageReport"))).isNotNull();
+  }
+
+  @Test
+  public void nullOwnerLabelDoesNotMatchLabelFilter() {
+    // When the action owner has no label, it should not match a specific label pattern.
+    var scrubber =
+        new Scrubber(
+            Config.newBuilder()
+                .addRules(
+                    Config.Rule.newBuilder()
+                        .setMatcher(Config.Matcher.newBuilder().setLabel("//foo:bar")))
+                .build());
+
+    assertThat(scrubber.forSpawn(createSpawnWithNullLabel("CoverageReport"))).isNull();
+  }
+
   private static Spawn createSpawn() {
     return createSpawn("//foo:bar", "Foo");
   }
@@ -463,5 +492,13 @@ public class ScrubberTest {
         .withOwnerRuleKind(ruleKind)
         .setBuiltForToolConfiguration(forTool)
         .build();
+  }
+
+  /**
+   * Creates a spawn whose action owner has no label, simulating synthetic Bazel actions such as
+   * {@code CoverageReportKeySingleton}.
+   */
+  private static Spawn createSpawnWithNullLabel(String mnemonic) {
+    return new SpawnBuilder("cmd").withNullOwnerLabel().withMnemonic(mnemonic).build();
   }
 }


### PR DESCRIPTION
Prior to this commit, there was an access to getLabel() with no null check. --combined_report=lcov creates an action with no label, causing a crash when the cache key scrubbing tries to determine whether to scrub the action.

In this commit we add a null check to avoid the crash.

Open source PR: https://github.com/bazelbuild/bazel/pull/29980
