### PR TITLE
[Android] Backport action cache cleanup fix from Bazel 9

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
@@ -253,7 +254,35 @@ public class CompactPersistentActionCache implements ActionCache {
       }
       misses.put(reason, new AtomicInteger(0));
     }
+    deleteUnrecognizedFiles(cacheRoot);
     return new CompactPersistentActionCache(indexer, map, Maps.immutableEnumMap(misses));
+  }
+
+  /**
+   * Deletes unrecognized files from the action cache on-disk directory.
+   *
+   * <p>This works around an incrementality bug when building a runfiles tree while alternating
+   * between Bazel versions. Specifically, because the runfiles output manifest is a symlink to the
+   * input manifest (and therefore always appears to have the contents of the latter), one can get a
+   * spurious cache hit for a stale runfiles tree if the tree was updated in an intervening build
+   * without the action cache being updated accordingly.
+   *
+   * <p>Backported from https://github.com/bazelbuild/bazel/pull/27525 (Bazel 9.0.0).
+   */
+  private static void deleteUnrecognizedFiles(Path cacheRoot) throws IOException {
+    Path indexFile = cacheRoot.getChild("filename_index_v" + VERSION + ".blaze");
+    Path indexJournalFile = cacheRoot.getChild("filename_index_v" + VERSION + ".journal");
+    ImmutableSet<Path> knownFiles =
+        ImmutableSet.of(
+            cacheFile(cacheRoot),
+            journalFile(cacheRoot),
+            indexFile,
+            indexJournalFile);
+    for (Path child : cacheRoot.getDirectoryEntries()) {
+      if (!knownFiles.contains(child)) {
+        child.delete();
+      }
+    }
   }
 
   private static CompactPersistentActionCache logAndThrowOrRecurse(

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -451,6 +451,15 @@ public class CompactPersistentActionCacheTest {
                 Optional.of(materializationExecPath)));
   }
 
+  @Test
+  public void testDeleteUnrecognizedFiles() throws Exception {
+    Path unrecognizedFile = dataRoot.getChild("unrecognized_file");
+    FileSystemUtils.writeContentAsLatin1(unrecognizedFile, "content");
+    assertThat(unrecognizedFile.exists()).isTrue();
+    CompactPersistentActionCache.create(dataRoot, clock, NullEventHandler.INSTANCE);
+    assertThat(unrecognizedFile.exists()).isFalse();
+  }
+
   private static void assertKeyEquals(ActionCache cache1, ActionCache cache2, String key) {
     Object entry = cache1.get(key);
     assertThat(entry).isNotNull();


### PR DESCRIPTION
Backport of the fix for https://github.com/bazelbuild/bazel/issues/26818 which causes Bazel 8 to corrupt the output base for Bazel 7 when alternating between versions on the same workspace.

The fix deletes unrecognized files from the action cache on-disk directory when loading it into memory. This prevents spurious cache hits for stale runfiles trees when the runfiles output manifest (a symlink to the input manifest) appears valid but the underlying tree was updated by an intervening build with a different Bazel version.

Original fix: https://github.com/bazelbuild/bazel/pull/27525
Original commit: 912099e4e7f80db291e3a67e8e445a9de9c90d6c


