### PR TITLE
Fix compile errors in 02e48afd8b (arg_replacements scrubbing)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/CommandLines.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/CommandLines.java
@@ -255,10 +255,6 @@ public abstract sealed class CommandLines {
     public ParameterFileType getType() {
       return type;
     }
-
-    public Charset getCharset() {
-      return charset;
-    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.remote.merkletree;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
@@ -164,15 +165,14 @@ class DirectoryTreeBuilder {
             if (spawnScrubber != null && virtualActionInput instanceof ParamFileActionInput) {
               ParamFileActionInput paramFile = (ParamFileActionInput) virtualActionInput;
               ImmutableList<String> scrubbedArgs =
-                  paramFile.getArguments().stream()
+                  Streams.stream(paramFile.getArguments())
                       .map(spawnScrubber::transformArgument)
                       .collect(ImmutableList.toImmutableList());
               virtualActionInput =
                   new ParamFileActionInput(
                       paramFile.getExecPath(),
                       scrubbedArgs,
-                      paramFile.getType(),
-                      paramFile.getCharset());
+                      paramFile.getType());
             }
             Digest d = digestUtil.compute(virtualActionInput);
             boolean childAdded =


### PR DESCRIPTION
  Commit 02e48afd8b ("Apply arg_replacements scrubbing to params file cache key hashing") introduced two compile errors in the Uber fork:

  1. CommandLines.java — getCharset() referenced a nonexistent charset field. The ParamFileActionInput constructor stores charset only in the superclass (ParameterFile) via super(), so there is no local field to return. Fixed by removing the getCharset() method entirely per author guidance.
  2. DirectoryTreeBuilder.java — called .stream() on paramFile.getArguments(), which returns Iterable<String>, not Collection. Iterable has no .stream() method. Fixed by using Guava's Streams.stream() instead. Also updated the ParamFileActionInput constructor call to use the 3-arg version (dropping the charset argument).
